### PR TITLE
Spoiler Log Colors

### DIFF
--- a/source/spoiler_log.cpp
+++ b/source/spoiler_log.cpp
@@ -283,6 +283,10 @@ static void WriteIngameSpoilerLog() {
               spoilerData.ItemLocations[spoilerItemIndex].RevealType = REVEALTYPE_ALWAYS;
               spoilerData.ItemLocations[spoilerItemIndex].CollectionCheckType = SPOILER_CHK_ALWAYS_COLLECTED;
             }
+            if (Location(key)->IsRepeatable())
+            {
+              spoilerData.ItemLocations[spoilerItemIndex].CollectType = COLLECTTYPE_REPEATABLE;
+            }
             auto checkGroup = loc->GetCollectionCheckGroup();
             spoilerData.ItemLocations[spoilerItemIndex].Group = checkGroup;
 


### PR DESCRIPTION
add extra check to mark repeatable locations as repeatable collect type so they appear as the correct color in the spoiler log