### PR TITLE
Bank Reward and Patch Fixes

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -543,7 +543,7 @@ void AreaTable_Init() {
 		LocationAccess(S_CLOCK_TOWN_FINAL_DAY_CHEST, {[] {return Hookshot || (DekuMask && MoonsTear);}}),
 		LocationAccess(S_CLOCK_TOWN_BANK_REWARD_1, {[] {return true;}}),
 		LocationAccess(S_CLOCK_TOWN_BANK_REWARD_2, {[] {return AnyWallet;}}),
-		LocationAccess(S_CLOCK_TOWN_BANK_REWARD_3, {[] {return AnyWallet;}}),
+		LocationAccess(S_CLOCK_TOWN_BANK_REWARD_3, {[] {return (OceanWallet500 || ProgressiveWallet > 1);}}),
 	},
 	{
 		//Exits


### PR DESCRIPTION
- **Fix**: Move Ocean Deed Patch code down a few instructions past an stmdb call.
- **Fix**: The Title Trade Items now properly respect only giving fishing passes to progressive items. (This may require more work for just all items under `0x49` instead?)
- **Fix**: Romani Mask hash string removed the capital O.
- **Fix**: Change logic to require a giant wallet or progressive wallet > 1.