### PR TITLE
Add Restoration Twinmold Option

### DIFF
--- a/source/include/setting_descriptions.hpp
+++ b/source/include/setting_descriptions.hpp
@@ -215,6 +215,7 @@ extern string_view fastZoraSwimDesc;
 extern string_view dpadMaskDesc;
 extern string_view dpadOcarinaDesc;
 extern string_view dpadArrowDesc;
+extern string_view twinmoldRestorationDesc;
 extern string_view customMapButtonDesc;
 extern string_view customItemsButtonDesc;
 extern string_view customMasksButtonDesc;

--- a/source/include/settings.hpp
+++ b/source/include/settings.hpp
@@ -448,6 +448,10 @@ namespace Settings {
   extern Option SkipSongReplays;
   extern Option FastZoraSwim;
   extern Option OcarinaDive;
+  extern Option DpadTransform;
+  extern Option DpadOcarina;
+  extern Option DpadArrows;
+  extern Option TwinmoldRestoraion;
 
   //Trial Skips
   extern Option OdolwaTrialSkip;

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -352,6 +352,7 @@ void AreaTable_Init() {
 	areaTable[CLOCK_TOWN_OBSERVATORY] = Area("Astral Observatory/Bombers Hideout", "Astral Obseravtory/Bombers Hideout", NONE, {
 		//Events
 		EventAccess(&WatchMoonTearFall, {[]{return true;}}),
+		EventAccess(&ScarecrowSong, {[]{return Ocarina;}}),
 	},
 	{
 		//Locations
@@ -502,6 +503,8 @@ void AreaTable_Init() {
 
 	areaTable[CLOCK_TOWN_TRADING_POST] = Area("Trading Post", "Trading Post", NONE, {
 		//Events
+		EventAccess(&ScarecrowSong, {[]{return Ocarina;}}),
+		EventAccess(&SpringWater,   {[]{return SpringWater;}}),
 	},
 	{
 		//Locations
@@ -1112,7 +1115,7 @@ void AreaTable_Init() {
 	{
 		//Exits
 		Entrance(TWIN_ISLANDS, {[]{return true;}}),
-		Entrance(TWIN_ISLANDS_GORON_RACETRACK_GROTTO, {[]{return AnyBombBag || (Hookshot || GoronMask);}}),
+		Entrance(TWIN_ISLANDS_GORON_RACETRACK_GROTTO, {[]{return AnyBombBag && ( (Hookshot && ScarecrowSong) || GoronMask);}}),
 	});
 
 	areaTable[TWIN_ISLANDS_GORON_RACETRACK_GROTTO] = Area("Goron Racetrack Grotto", "Goron Racetrack Grotto", NONE, {
@@ -1211,7 +1214,7 @@ void AreaTable_Init() {
 	}, 
 	{
 		//Locations
-		LocationAccess(ROAD_TO_SNOWHEAD_PILLAR, {[] {return GoronMask && MagicMeter && LensOfTruth;}}),
+		LocationAccess(ROAD_TO_SNOWHEAD_PILLAR, {[] {return GoronMask && MagicMeter && LensOfTruth && Hookshot && ScarecrowSong;}}),
 
 	},
 	{
@@ -3332,7 +3335,7 @@ void AreaTable_Init() {
 	}, 
 	{
 		//Locations
-		LocationAccess(BENEATH_THE_WELL_MIRROR_SHIELD_CHEST, {[] {return (FireArrows || LightArrows) && Bow && MagicMeter;}}),//Either burn the cloth or just light arow the switch
+		LocationAccess(BENEATH_THE_WELL_MIRROR_SHIELD_CHEST, {[] {return FireArrows && Bow && MagicMeter;}}),//Either burn the cloth or just light arow the switch
 	},
 	{
 		//Exits

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -613,10 +613,12 @@ string_view ocarinaDiveDesc          = "Enables Ocarina Diving";                
 string_view dpadMaskDesc             = "Enables using the 3 D-Pad buttons to use\n"        //
                                        "transformation masks. This option will also\n"     //
                                        "patch using Down A with Mask Storage.";            //
-string_view dpadOcarinaDesc          = "Enables using D-Pad down to activate your\n"       //
+string_view dpadOcarinaDesc          = "Enables using D-Pad right to activate your\n"      //
                                        "ocarina.";                                         //
 string_view dpadArrowDesc            = "Enables using D-Pad up to change your current\n"   //
                                        "arrow that is being used.";                        //
+string_view twinmoldRestorationDesc  = "Fixes Twinmold boss fight so Red Twinmold does not\n"
+                                       "regen health when it burrows.";                    //
                                                                                            //
 /*-------------------------------                                                          //
 |   CUSTOM BUTTON MAPPING       |                                                          //

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -397,6 +397,7 @@ namespace Settings {
   Option DpadTransform       = Option::Bool("DPad Transformation",    { "No", "Yes" },                                       {dpadMaskDesc});
   Option DpadOcarina         = Option::Bool("DPad Ocarina",           { "No", "Yes" },                                       {dpadOcarinaDesc});
   Option DpadArrows          = Option::Bool("Dpad Arrow Swap",        { "No", "Yes" },                                       {dpadArrowDesc});
+  Option TwinmoldRestoration  = Option::Bool("Twinmold Restoration",   { "No", "Yes" },                                      {twinmoldRestorationDesc});
 
   std::vector<Option *> restorationOptions = {
     //&SkipMinigamePhases,
@@ -412,6 +413,7 @@ namespace Settings {
     &DpadTransform,
     &DpadOcarina,
     &DpadArrows,
+    &TwinmoldRestoration,
     //&SkipSongReplays,
   };
 
@@ -775,6 +777,7 @@ namespace Settings {
     ctx.enableFastMaskTransform = (DpadTransform) ? 1 : 0;
     ctx.enableFastOcarina = (DpadOcarina) ? 1 : 0;
     ctx.enableFastArrowSwap = (DpadArrows) ? 1 : 0;
+    ctx.twinmoldRestoration = (TwinmoldRestoration) ? 1 : 0;
 
     //Cutscene Skips
     ctx.skipHMSCutscenes = (SkipHMSCutscenes) ? 1 : 0;

--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -96,6 +96,7 @@ void GenerateStartingInventory() {
   if (StartingKokiriSword.Value<u8>() == (u8)3){ AddItemToInventory(PROGRESSIVE_SWORD, 0);}
   if (StartingShield.Value<u8>() == (u8)0){  AddItemToInventory(HEROS_SHIELD,              1);}
   if (StartingShield.Value<u8>() == (u8)1){  AddItemToInventory(MIRROR_SHIELD,             1);}
+  AddItemToInventory(GREAT_FAIRYS_SWORD,        StartingGreatFairySword.Value<u8>());
   AddItemToInventory(PROGRESSIVE_MAGIC_METER,   StartingMagicMeter.Value<u8>());
   AddItemToInventory(PROGRESSIVE_WALLET,        StartingWallet.Value<u8>());
   AddItemToInventory(DOUBLE_DEFENSE,            StartingDoubleDefense.Value<u8>());


### PR DESCRIPTION
- Adds toggle for Twinmold Restoration
- Fixes Great Fairy's Sword starting inventory option to actually remove the sword from the pool when toggled on
- Fixes description on D-Pad Ocarina to show D-Pad Right instead of D-Pad Down
- Fixes Twin Islands Goron Racetrack Grotto Requirements
- Fixes Road to Snowhead Pillar HP Requirements to require Hookshot
- Removes Light Arrows as potential requirement from Beneath the Well Mirror Shield Chest
- Add in new check for Kaepora Gabora to not spawn if you have both Lens and magic. Otherwise, the owl will spawn.