### PR TITLE
Gilded Sword Check Prereq Fix and WFT, SHT, and GBT SF Logic Adjustments 

### DIFF
--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2295,7 +2295,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Locations
-		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || ZoraMask && (GoronMask || (Bow && FireArrows && MagicMeter) || AnyBombBag);}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
+		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || (ZoraMask && (GoronMask || (Bow && FireArrows && MagicMeter) || AnyBombBag));}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
 		LocationAccess(SH_SF_ICICLE_ROOM_WALL, {[] {return Bow && GreatFairyMask && LensOfTruth && MagicMeter;}}),
 	},
 	{
@@ -2392,7 +2392,7 @@ void AreaTable_Init() {
 	{
 		//Exits
 		Entrance(SNOWHEAD_TEMPLE_MAIN_ROOM_3F, {[]{return SmallKeys(SnowheadTempleKeys, 3);}}),
-		Entrance(SNOWHEAD_TEMPLE_DINOLFOS_ROOM, {[]{return;}}) //Need Fire Arrows to melt the ice and progress, but you can also just jump down
+		Entrance(SNOWHEAD_TEMPLE_DINOLFOS_ROOM, {[]{return true;}}) //Need Fire Arrows to melt the ice and progress, but you can also just jump down
 	});
 
 	areaTable[SNOWHEAD_TEMPLE_MAIN_ROOM_4F] = Area("Snowhead Temple Main Room 4F", "Snowhead Temple Main Room 4F", SNOWHEAD_TEMPLE, {

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -1064,7 +1064,7 @@ void AreaTable_Init() {
 	{
 		//Locations
 		LocationAccess(MOUNTAIN_VILLAGE_SMITH_DAY_ONE, {[] {return AnyWallet && ( HotSpringWater || SnowheadClear || (Bow && MagicMeter && FireArrows));}}),
-		LocationAccess(MOUNTAIN_VILLAGE_SMITH_DAY_TWO, {[] {return GoronRaceBottle && AnyWallet (HotSpringWater || SnowheadClear || (Bow && MagicMeter && FireArrows));}}), //Currently need at least one progressive wallet as these are not independent checks
+		LocationAccess(MOUNTAIN_VILLAGE_SMITH_DAY_TWO, {[] {return GoronRaceBottle && AnyWallet && (HotSpringWater || SnowheadClear || (Bow && MagicMeter && FireArrows));}}), //Currently need at least one progressive wallet as these are not independent checks
 	},
 	{
 		//Exits

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2532,7 +2532,7 @@ void AreaTable_Init() {
 	{
 		//Locations
 		LocationAccess(GBT_MAP_CHEST, {[] {return ZoraMask && (Hookshot || (Bow && MagicMeter && IceArrows));}}),
-		LocationAccess(GBT_SF_LEDGE_JAR, {[] {return ZoraMask && (Hookshot || Bow) && || (GreatFairyMask || (Bow && MagicMeter && IceArrows));}}), //Shoot to break pot and either get with GFM or ice platforms
+		LocationAccess(GBT_SF_LEDGE_JAR, {[] {return ZoraMask && (Hookshot || Bow) && (GreatFairyMask || (Bow && MagicMeter && IceArrows));}}), //Shoot to break pot and either get with GFM or ice platforms
 	},
 	{
 		//Exits

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2295,7 +2295,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Locations
-		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || ZoraMask && (GoronMask || (Bow && FireArrows && MagicMeter) || AnyBombBag;}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
+		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || ZoraMask && (GoronMask || (Bow && FireArrows && MagicMeter) || AnyBombBag);}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
 		LocationAccess(SH_SF_ICICLE_ROOM_WALL, {[] {return Bow && GreatFairyMask && LensOfTruth && MagicMeter;}}),
 	},
 	{
@@ -2501,7 +2501,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Locations
-		LocationAccess(GBT_SF_WHIRLPOOL_JAR, {[] {return ZoraMask || (Bow && GreatFairyMask;}}), //Swim down or shoot pot with bow and get with mask on
+		LocationAccess(GBT_SF_WHIRLPOOL_JAR, {[] {return ZoraMask || (Bow && GreatFairyMask);}}), //Swim down or shoot pot with bow and get with mask on
 		LocationAccess(GBT_SF_WHIRLPOOL_BARREL, {[] {return true;}}), //Climb the ladder and bonk
 	},
 	{

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -2295,7 +2295,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Locations
-		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || ZoraMask && (GoronMask || FireArrows && MagicMeter || AnyBombBag;}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
+		LocationAccess(SNOWHEAD_TEMPLE_ICICLE_ROOM_CHEST, {[] {return Bow || ZoraMask && (GoronMask || (Bow && FireArrows && MagicMeter) || AnyBombBag;}}), //Either shoot the icicles down or climb up as Zora and break snow boulder
 		LocationAccess(SH_SF_ICICLE_ROOM_WALL, {[] {return Bow && GreatFairyMask && LensOfTruth && MagicMeter;}}),
 	},
 	{


### PR DESCRIPTION
Made it so that you need at least 1 progressive wallet to do Gilded Sword check, since Razor Sword check is required to do it.

WFT, SHT, and GBT had some Stray Fairy adjustments.