### PR TITLE
Update Build Process

### DIFF
--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -429,7 +429,7 @@ jobs:
               LINE=`sed -e 's/^"//' -e 's/"$//' <<<"$LINE"`
               ARRLINE=($(echo $LINE | tr " " "\n"))
               sed -i "s#<NIGHTLY_${LINENUM}_URL_CIA>#${ARRLINE[0]}#g" MM3DR.unistore
-              VERSION=$(echo ${ARRLINE[0]} | cut -c75-80)
+              VERSION=$(echo ${ARRLINE[0]} | cut -c67-72)
               MODIFIED=$(echo ${ARRLINE[1]} | cut -c1-10)
               MODIFIED_DATE=$(echo ${ARRLINE[1]} | cut -c12-19)
               sed -i "s#<NIGHTLY_$LINENUM>#$VERSION#g" MM3DR.unistore


### PR DESCRIPTION
The `cut` call was not correctly aligned with the repo, so it was not giving proper hashes for the versions.