### PR TITLE
GitHub Actions Update

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -23,7 +23,7 @@ jobs:
     name: Confirm Compilable
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/z3dr/randotools:latest
+      image: ghcr.io/z3dr/randotools:next
 
     steps:      
     - name: Checkout Project

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
 
 jobs:
-  format:
-    name: Verify Formatting
-    runs-on: ubuntu-latest
+  # format:
+  #   name: Verify Formatting
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout Project
-      uses: actions/checkout@v3
+  #   steps:
+  #   - name: Checkout Project
+  #     uses: actions/checkout@v4
 
 #    - name: Format Project
 #      uses: DoozyX/clang-format-lint-action@v0.15
@@ -27,7 +27,7 @@ jobs:
 
     steps:      
     - name: Checkout Project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         submodules: true
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
+      options: --user 1001
 
     steps:      
     - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -47,7 +47,7 @@ jobs:
     name: Build CIA and 3DSX Files
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/z3dr/randotools:latest
+      image: ghcr.io/z3dr/randotools:next
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
       - name: Get Last Nightly Commit and Private Key
@@ -34,7 +34,7 @@ jobs:
           
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.3.0
+        uses: metcalfc/changelog-generator@v4.3.1
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ env.last_nightly }}
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
         with:
           submodules: true
 

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
+      options: --user 1001
 
     steps:
       - name: Checkout Project

--- a/source/include/version.hpp
+++ b/source/include/version.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-#define RANDOMIZER_VERSION "v1.3.4"
+#define RANDOMIZER_VERSION "v1.4.0"
 #define COMMIT_NUMBER "develop"

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -144,7 +144,7 @@ namespace Settings {
   Option StartingKokiriSword       = Option::U8("Sword",                  { "Kokiri Sword",     "Razor Sword", "Gilded Sword", "None" },                     { "" }, OptionCategory::Setting, (u8)StartingSwordSetting::STARTINGSWORD_KOKIRI);//1U = StartingSwordSetting::STARTINGSWORD_KOKIRI
   Option StartingGreatFairySword   = Option::U8("Great Fairy Sword",      { "None",             "G. F. S." },                                                { "" });
   Option StartingShield            = Option::U8("Shield",                 { "Hero's Shield",    "Mirror Shield", "None" },                                   { "" }, OptionCategory::Setting, (u8)StartingSheildSetting::STARTINGSHIELD_HERO);//1U = StartingShieldSetting::STARTINGSHIELD_HERO
-  Option StartingWallet            = Option::U8("Wallet Upgrade",         { "None",             "Adult's Wallet",   "Giant's Wallet" ,  "Tycoon's Wallet" }, { "" }, OptionCategory::Setting, (u8)StartingWalletSetting::STARTINGWALLET_NONE);
+  Option StartingWallet            = Option::U8("Wallet Upgrade",         { "None",          "Adult's Wallet",   "Giant's Wallet"/*,  "Tycoon's Wallet"*/ }, { "" }, OptionCategory::Setting, (u8)StartingWalletSetting::STARTINGWALLET_NONE);
   Option StartingHealth            = Option::U8("Health",                 healthOptions,                                                                     { "" });
   Option StartingMagicMeter        = Option::U8("Magic Meter",            { "None",             "Single Magic",     "Double Magic" },                        { "" });
   Option StartingDoubleDefense     = Option::U8("Double Defense",         { "None",             "Double Defense" },                                          { "" });


### PR DESCRIPTION
This moves the builder to a newer version of the docker randotools container, as well as updates the sub repo to the latest dev build.

We have also removed Tycoon wallet, as we do not have that implemented yet and it was confusing for users.
Adjusted savefile logic to (hopefully) fix bigger quiver and bomb bags giving the proper counts for items.