### PR TITLE
Deploy French and Spanish

### DIFF
--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -184,12 +184,12 @@ void CreateMessageFromTextObject(u16 textId, u16 field_2, u32 field_4, u32 flags
                    u16 sfx, bool instant, bool repeatSfx) {
     CreateMessage(textId, field_2, field_4, flags,
                 //      NaEnglish                     NaFrench                      NaSpanish
-                  {text.GetNAEnglish().c_str(), /*text.GetNAFrench().c_str(), text.GetNASpanish().c_str(),
+                  {text.GetNAEnglish().c_str(), text.GetNAFrench().c_str(), text.GetNASpanish().c_str(),
                 // Remember to update these alongside Text class when adding languages
                 //      EuGerman                      EuItalian                     Japanese
                 text.GetEUREnglish().c_str(), text.GetEUREnglish().c_str(), // text.GetNAEnglish().c_str(),
                 //      EuEnglish                     EuFrench                      EuSpanish
-                text.GetEUREnglish().c_str(), text.GetEURFrench().c_str(), text.GetEURSpanish().c_str()*/
+                text.GetEUREnglish().c_str(), text.GetEURFrench().c_str(), text.GetEURSpanish().c_str()
                 }, cols, icons, delays, sfx, instant, repeatSfx);
 }
 

--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -206,105 +206,143 @@ void CreateBaselineCustomMessages() {
     delayData.push_back(0x3F);
     colParity = iconParity = delayParity = 1;
 
+    Text GITextIntroSKey =    {"You got a #small key# ",       "Vous obtenez une #petite clé# ",     "¡Has obtenido una #llave pequeña# "};
+    Text GITextIntroMap =     {"You found the #dungeon map# ", "Vous obtenez la #carte du donjon# ", "¡Has encontrado el #mapa de la mazmorra# "};
+    Text GITextIntroCompass = {"You got the #compass# ",       "Vous obtenez la #boussole# ",        "¡Has encontrado la #brújula# "};
+    Text GITextIntroBKey =    {"You got the #boss key# ",      "Vous obtenez la #grande clé# ",      "¡Has obtenido la #gran llave# "};
+
+    Text GITextDungeonWoodfall =   {"for #Woodfall Temple#!",    "du #temple de Boisé-les-Cascades#!",       "del templo del Bosque Catarata!",
+                                    "",                          "du #temple de Bois-Cascade# !",            ""};
+    Text GITextDungeonSnowhead =   {"for #Snowhead Temple#!",    "du #temple du Pic des neiges#!",           "del templo del Pico Nevado!",
+                                    "",                          "du #temple du pic des Neiges# !",          ""};
+    Text GITextDungeonGreatBay =   {"for #Great Bay Temple#!",   "du #temple de la Grande Baie#!",           "del templo de la Gran Bahía!",
+                                    "",                          "du #temple de la Grande Baie# !",          ""};
+    Text GITextDungeonStoneTower = {"for #Stone Tower Temple#!", "du #temple de la forteresse de pierre#!",  "del templo de la Torre de Piedra!",
+                                    "",                          "du #temple de la forteresse de pierre# !", ""};
+
+    Text GITextOutroSKey =    {
+        " Use it to open a locked door in that temple.", " Utilisez-la pour ouvrir une porte de ce donjon.", ""
+    };
+    Text GITextOutroCompass = {
+        " Now many of the dungeon's hidden things will appear on the map!", " Certains des secrets de ce donjon seront maintenant visibles sur la carte!",  "",
+        "",                                                                 " Certains des secrets de ce donjon seront maintenant visibles sur la carte !", ""
+    };
+    Text GITextOutroBKey =    {
+        " Now you can enter the chamber where the boss lurks!", " Vous pouvez maintenant pénétrer dans l'antre du boss!",  "",
+        "",                                                     " Vous pouvez maintenant pénétrer dans l'antre du boss !", ""
+    };
+
     // Small Keys
     // Woodfall
-    CreateMessage(0x6133, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got a #small key# for the #Woodfall Temple#! Use it to open a locked door in that temple."},
-    {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6133, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroSKey + GITextDungeonWoodfall + GITextOutroSKey,
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
     // Snowhead
-    CreateMessage(0x6134, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got a #small key# for the #Snowhead Temple#! Use it to open a locked door in that temple."},
-    {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6134, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroSKey + GITextDungeonSnowhead + GITextOutroSKey,
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
     // Great Bay
-    CreateMessage(0x6135, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got a #small key# for the #Great Bay Temple#! Use it to open a locked door in that temple."},
-    {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6135, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroSKey + GITextDungeonGreatBay + GITextOutroSKey,
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
     // Stone Tower
-    CreateMessage(0x6136, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got a #small key# for the #Stone Tower Temple#! Use it to open a locked door in that temple."},
-    {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6136, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroSKey + GITextDungeonStoneTower + GITextOutroSKey,
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
 
     // Maps
     // Woodfall
-    CreateMessage(0x6137, 0x003E, 0x3FFFFFFF, 0xFF0000, 
-    {"You found the #dungeon map# for the #Woodfall#!"},
-    {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6137, 0x003E, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroMap + GITextDungeonWoodfall,
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
 
     // Snowhead
-    CreateMessage(0x6138, 0x003E, 0x3FFFFFFF, 0xFF0000, 
-    {"You found the #dungeon map# for the #Snowhead#!"},
-    {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6138, 0x003E, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroMap + GITextDungeonSnowhead,
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
 
     // Great Bay
-    CreateMessage(0x6139, 0x003E, 0x3FFFFFFF, 0xFF0000, 
-    {"You found the #dungeon map# for the #Great Bay#!"},
-    {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6139, 0x003E, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroMap + GITextDungeonGreatBay,
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
 
     // Stone Tower
-    CreateMessage(0x613A, 0x003E, 0x3FFFFFFF, 0xFF0000, 
-    {"You found the #dungeon map# for the #Stone Tower#!"},
-    {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613A, 0x003E, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroMap + GITextDungeonStoneTower,
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
 
     // Compasses
     // Woodfall
-    CreateMessage(0x613B, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #compass# for the #Woodfall Temple#! Now many of the dungeon's hidden things will appear on the map!"},
-    {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613B, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroCompass + GITextDungeonWoodfall + GITextOutroCompass,
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
 
     // Snowhead
-    CreateMessage(0x613C, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #compass# for the #Snowhead Temple#! Now many of the dungeon's hidden things will appear on the map!"},
-    {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613C, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroCompass + GITextDungeonSnowhead + GITextOutroCompass,
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
 
     // Great Bay
-    CreateMessage(0x613D, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #compass# for the #Great Bay Temple#! Now many of the dungeon's hidden things will appear on the map!"},
-    {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613D, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroCompass + GITextDungeonGreatBay + GITextOutroCompass,
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
 
     // Stone Tower
-    CreateMessage(0x613E, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #compass# for the #Stone Tower Temple#! Now many of the dungeon's hidden things will appear on the map!"},
-    {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613E, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroCompass + GITextDungeonStoneTower + GITextOutroCompass,
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
 
     // Boss Keys
     // Woodfall
-    CreateMessage(0x613F, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #boss key# for the #Woodfall Temple#! Now you can enter the chamber where the boss lurks!"},
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x613F, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroBKey + GITextDungeonWoodfall + GITextOutroBKey,
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     // Snowhead
-    CreateMessage(0x6140, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #boss key# for the #Snowhead Temple#! Now you can enter the chamber where the boss lurks!"},
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6140, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroBKey + GITextDungeonSnowhead + GITextOutroBKey,
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     // Great Bay
-    CreateMessage(0x6141, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #boss key# for the #Great Bay Temple#! Now you can enter the chamber where the boss lurks!"},
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6141, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroBKey + GITextDungeonGreatBay + GITextOutroBKey,
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     // Stone Tower
-    CreateMessage(0x6142, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #boss key# for the #Stone Tower Temple#! Now you can enter the chamber where the boss lurks!"},
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    CreateMessageFromTextObject(0x6142, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+        GITextIntroBKey + GITextDungeonStoneTower + GITextOutroBKey,
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     // Kokiri Sword
-    CreateMessage(0x0037, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"You got the #Kokiri Sword!# The trusty sword you're familiar with. A treasure from Kokiri Forest."},
+    CreateMessage(0x0037, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
+    {"You got the #Kokiri Sword!# The trusty sword you're familiar with. A treasure from Kokiri Forest.",
+        // French
+        "Vous obtenez l'#épée Kokiri#! Votre fidèle épée qui provient de le forêt Kokiri.",
+    },
     {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     // Ice Trap
     CreateMessage(0x0012, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
-    {"          #FOOL!#"},
+    {"          #FOOL!#",
+        // French
+        "#IDIOT!#",
+    },
     {QM_RED}, {}, {}, 0x0, false, false);
 
     //Swamp Skulltula Tokens
     CreateMessage(0x0052, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
-    {"You got a #Swamp Skulltula Token#! &You have collected #=SSH#."},
+    {"You got a #Swamp Skulltula Token#! &You have collected #=SSH#.",
+        // French
+        "Vous obtenez l'#âme d'une skulltula d'or des marais#!&Vous en avez désormais #=SSH#.",
+    },
     {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
 
     //Ocean Skulltula Tokens
     CreateMessage(0x6143, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
-    {"You got an #Ocean Skulltula Token#! &You have collected #=OSH#."},
+    {"You got an #Ocean Skulltula Token#! &You have collected #=OSH#.",
+        // French
+        "Vous obtenez l'#âme d'une skulltula d'or de la côte#!&Vous en avez désormais #=OSH#.",
+    },
     {QM_BLUE, QM_RED}, {}, {}, 0x0, false, false);
 
 }

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -448,11 +448,11 @@ void CreateTingleHintText() {
         Text greatBayMap = Text{"#"}+ItemTable(Location(TINGLE_GBC_GB)->GetPlacedItemKey()).GetName();
         Text ikanaMap = Text{"#"}+ItemTable(Location(TINGLE_GBC_ST)->GetPlacedItemKey()).GetName();
 
-        //               {"English", "French", "Spanish"}
-        Text priceFive = {"    ##5 Rupees#&", "    ##5 Rubis#&", "    ##5 rupias#&"};
-        Text priceTwenty = {"    ##20 Rupees#&", "    ##20 Rubis#&", "    ##20 rupias#&"};
-        Text priceForty = {"    ##40 Rupees#", "    ##40 Rubis#", "    ##40 rupias#"};
-        Text leaveShop = {"&#No thanks#", "&#Non merci#", "&#No, gracias#"};
+        //                 {"English",           "French",           "Spanish"          };      "German"            "Italian"
+        Text priceFive =   {"    ##5 Rupees#&",  "    ##5 Rubis#&",  "    ##5 rupias#&"}; // ,  " - ##5 Rubine#&",  "    ##5 rupie#&"
+        Text priceTwenty = {"    ##20 Rupees#&", "    ##20 Rubis#&", "    ##20 rupias#&"}; // , " - ##20 Rubine#&", "    ##20 rupie#&"
+        Text priceForty =  {"    ##40 Rupees#",  "    ##40 Rubis#",  "    ##40 rupias#"}; // ,  " - ##40 Rubine#",  "    ##40 rupie#"
+        Text leaveShop =   {"&#No thanks#",      "&#Non merci#",     "&#No, gracias#"}; // ,    "&#Nein, danke!#",  "&#No, grazie#"
 
         // Clock Town message
         CustomMessages::CreateMessageFromTextObject(0x1D11, 0xFFFF, 0x3FF0A005, 0xFF1001,
@@ -504,9 +504,12 @@ static Text BuildDoorText(const ItemKey itemKey) {
 void CreateClockTowerDoorHints() {
   // Create hint text
   Text ocarinaHint = Text{
-    /*English*/"Hey, didn't you have some sort of #musical instrument#?&If I know the Skull Kid, I bet he hid it at ",
-    /*French */"Dis, t'avais pas un #instrument de musique#?&Je parie que Skull Kid, l'a caché vers ",
-    /*Spanish*/"**SPANISH** "
+    /*NaEnglish*/"Hey, didn't you have some sort of #musical instrument#?&If I know the Skull Kid, I bet he hid it at ",
+    /*NaFrench */"Dis, t'avais pas un &#instrument de musique#?&Je parie que Skull Kid, l'a caché vers ",
+    /*NaSpanish*/"**SPANISH** ",
+    /*EuEnglish*/"",
+    /*EuFrench */"Dis, t'avais pas un &#instrument de musique# ?&Je parie que Skull Kid, l'a caché vers ",
+    /*EuSpanish*/""
   }+BuildDoorText(OCARINA_OF_TIME);
   Text odolwaHint = Text{
     /*English*/"There's one with a #crown# and #jewellery# said to be found at ",
@@ -594,14 +597,33 @@ void CreateClockTowerDoorHints() {
 
   CustomMessages::CreateMessage(0x0630, (StartingOcarina.Value<u8>() == 0) ? 0x8000 : 0x8002, 0x3FFFFFFF, 0x0FF0211,
     {"Rooftop access strictly prohibited!&(Enforceable until #midnight# on the&#eve# of the carnival.)^"
-    "#Notice of carnival activities:#&Musical Performance Contest&Unique Mask Contest&#Prizes available!#"},
+    "#Notice of carnival activities:#&Musical Performance Contest&Unique Mask Contest&#Prizes available!#",
+      // French
+      "Accès aux toits strictement&interdit jusqu'à #minuit#, la&#veille #du carnaval.^"
+      "#Notice d'activités du carnaval:#&Concours de performance musicale&Concours de masques singuliers&#Prix à la clé!#",
+      // Spanish
+      "Acceso al tejado.&¡Prohibida la entrada hasta&la #medianoche de la víspera&#del carnaval!^"
+      "**SPANISH**",
+      // // German
+      // "Zugang zum Dach&Betreten streng verboten!&(bis um #Mitternacht# am&Vorabend des #Karnevals#)^"
+      // "**GERMAN**",
+      // // Italian
+      // "Porta del tetto&Ingresso vietato fino alla&#mezzanotte# della #vigilia# del&carnevale.^"
+      // "**ITALIAN**",
+    },
     {QM_RED, QM_RED, QM_RED, QM_MAGENTA}, {}, {}, 0x0, false, false);
   CustomMessages::CreateMessageFromTextObject(0x8000, 0x8001, 0x3FFFFFFF, 0x1000000, ocarinaHint, {QM_BLUE, QM_RED}, {}, {}, 0x083E, false, false);
   CustomMessages::CreateMessage(0x8001, 0x8003, 0x3FFFFFFF, 0x1FF0000,
-    {"Also, that #mask competition# sounds interesting! I've heard rumours of some pretty #rare masks# around here, truly one of a kind stuff!"},
+    {"Also, that #mask competition# sounds interesting! I've heard rumours of some pretty #rare masks# around here, truly one of a kind stuff!",
+      // French
+      "D'ailleurs, ce #concours de masques# me rappelle que j'ai entendu des rumeurs dans le coin sur des #masques très uniques#.",
+    },
     {QM_RED, QM_RED}, {}, {}, 0x0, false, false);
   CustomMessages::CreateMessage(0x8002, 0x8003, 0x3FFFFFFF, 0x1FF0000,
-    {"Hey, that #mask competition# sounds interesting! I've heard rumours of some pretty #rare masks# around here, truly one of a kind stuff!"},
+    {"Hey, that #mask competition# sounds interesting! I've heard rumours of some pretty #rare masks# around here, truly one of a kind stuff!",
+      // French
+      "Dis, ce #concours de masques# me rappelle que j'ai entendu des rumeurs dans le coin sur des #masques très uniques#.",
+    },
     {QM_RED, QM_RED}, {}, {}, 0x083E, false, false);
   CustomMessages::CreateMessageFromTextObject(0x8003, 0x8004, 0x3FFFFFFF, 0x15D0000, odolwaHint, {QM_GREEN, QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
   CustomMessages::CreateMessageFromTextObject(0x8004, 0x8005, 0x3FFFFFFF, 0x15E0000, gohtHint, {QM_MAGENTA, QM_MAGENTA, QM_RED}, {}, {}, 0x0, false, false);
@@ -643,9 +665,12 @@ void CreateMoonChildHint() {
 
   // Add opening and closing textboxes to hint
   moonChildHint = Text{
-    /*English*/"You...^You don't have many masks...do you?",
-    /*French */"Toi...^Tu n'as pas beaucoup de masques... n'est-ce pas ?",
-    /*Spanish*/"**SPANISH**"
+    /*NaEnglish*/"You...^You don't have many masks...do you?",
+    /*NaFrench */"Toi...^Tu n'as pas beaucoup de masques... n'est-ce pas?",
+    /*NaSpanish*/"**SPANISH**",
+    /*EuEnglish*/"",
+    /*EuFrench */"Toi...^Tu n'as pas beaucoup de masques... n'est-ce pas ?",
+    /*EuSpanish*/""
   }+moonChildHint+Text{
     /*English*/"^Then we can play.",
     /*French */"^Alors, on pourra jouer.",

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -638,16 +638,25 @@ string_view skipGiantCutsceneDesc   = "Skips the cutscene of the giants catching
 |        REGION OPTIONS        |                                                           //
 ------------------------------*/                                                           //
 string_view NARegionDesc            = "                 North America\n"                   //
-                                      "Currently only supports English Hints and Custom Text";
+                                      "All three languages are supported,\n"               //
+                                      "but Spanish Custom Text is incomplete,\n"           //
+                                      "and ingame Spoiler Log is English only";            //
 string_view EURegionDesc            = "                     Europe\n"                      //
-                                      "Currently only supports English Hints and Custom Text";
+                                      "Ingame Spoiler Log is English only\n\n"             //
+                                      "Hints and Custom Text currently only support\n"     //
+                                      "English, French, and Spanish\n\n"                   //
+                                      "Expect inaccuracies in Spanish Custom Text, since\n"//
+                                      "Latin Spanish (incomplete) is used instead";        //
 string_view VersionDesc             = "Due to patch size when using version 1.1 it can \n" //
                                       "take up to 30 seconds to launch the game, this is\n"//
                                       "expected and will not effect gameplay";             //
 string_view LanguageDesc            = "Selected region differs from console meaning a\n"   //
                                       "locale.txt file will need to be generated\n\n"      //
-                                      "Please select your preferred language\n"            //
-                                      "NOTE: custom text still only supports English";     //
+                                      "Please select your preferred language\n\n"          //
+                                      "NOTE: Custom Text and Hints don't \n"               //
+                                      "support German or Italian yet.\n"                   //
+                                      "Also, Spanish is incomplete and will currently \n"  //
+                                      "be Latin Spanish regardless of game region";        //
 /*------------------------------                                                           //
 |  REPEATABLE ITEMS ON TOKENS  |                                                           //
 ------------------------------*/                                                           //
@@ -656,7 +665,7 @@ string_view repeatItemsOnTokensDesc = "Allows items potentially needed more than
                                       "to be placed on gold skulltula drops";              //
 /*------------------------------                                                           //
 | MOON AND MAJORA REQUIREMENTS |                                                           //
-------------------------------*/                                                          //
+------------------------------*/                                                           //
 string_view MoonRemainsRequiredDesc = "Select the number of Boss Remains needed to \n"     //
                                       "enter the moon by playing Oath to Order on the roof";//
 string_view MajoraRemainsRequiredDesc="Select the number of Boss Remains needed to \n"     //


### PR DESCRIPTION
- Use all three languages from hint tables
- Add more languages to messages outside hint tables
- Break dungeon item messages into interchanged parts

Spanish has some missing strings, but I believe most crucial info will be conveyed in *some* way