### PR TITLE
fix: Adjust Github Actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
+      options: --user 1001
 
     steps:      
     - name: Checkout Project

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,13 +1,5 @@
 name: MM3DR Build Check
 
-env:
-  # These are used automatically by git
-  GIT_AUTHOR_NAME: ${{ github.actor }}
-  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
-  GIT_COMMITTER_NAME: GitHub Actions
-  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-
-
 on:
   pull_request:
 
@@ -15,9 +7,11 @@ jobs:
   build:
     name: Confirm Compilable
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     container:
       image: ghcr.io/z3dr/randotools:next
-      options: --user 1001
+    
 
     steps:      
     - name: Checkout Project
@@ -39,3 +33,9 @@ jobs:
         chmod +x write_version.sh
         make -j
         mv -v MM3D_Randomizer.3dsx ${{ env.artifact_name }}.3dsx
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ env.artifact_name }}
+        path: ${{ env.artifact_name }}.3dsx

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,6 +11,7 @@ jobs:
       contents: write
     container:
       image: ghcr.io/z3dr/randotools:next
+      options: --user 1001
     
 
     steps:      

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,7 +30,6 @@ jobs:
       
     - name: Compile Project
       run: |
-        chmod +x write_version.sh
         make -j
         mv -v MM3D_Randomizer.3dsx ${{ env.artifact_name }}.3dsx
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,24 +1,17 @@
 name: MM3DR Build Check
 
+env:
+  # These are used automatically by git
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub Actions
+  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+
 on:
   pull_request:
 
 jobs:
-  # format:
-  #   name: Verify Formatting
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #   - name: Checkout Project
-  #     uses: actions/checkout@v4
-
-#    - name: Format Project
-#      uses: DoozyX/clang-format-lint-action@v0.15
-#      with:
-#        source: "./code ./source"
-#        extensions: 'c,h,cpp,hpp'
-#        clangFormatVersion: 14
-
   build:
     name: Confirm Compilable
     runs-on: ubuntu-latest
@@ -28,10 +21,21 @@ jobs:
 
     steps:      
     - name: Checkout Project
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v6.0.2
       with:
         submodules: true
-
+    
+    - name: Set Env Vars
+      shell: bash
+      run: |
+        pr_number=$(echo ${{ github.ref }} | cut -d / -f 3)
+        echo pr_number="$pr_number" | tee -a $GITHUB_ENV
+        short_sha=${GITHUB_SHA::6}
+        echo short_sha="$short_sha" | tee -a $GITHUB_ENV
+        echo artifact_name=MM3D_Randomizer_PR"$pr_number"_"$short_sha" | tee -a $GITHUB_ENV
+      
     - name: Compile Project
       run: |
+        chmod +x write_version.sh
         make -j
+        mv -v MM3D_Randomizer.3dsx ${{ env.artifact_name }}.3dsx

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
-      options: --user 1001
 
     steps:      
     - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
+      options: --user 1001
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -52,6 +52,7 @@ jobs:
       contents: write
     container:
       image: ghcr.io/z3dr/randotools:latest
+      options: --user 1001
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -64,7 +64,6 @@ jobs:
           GITHUB_BUILD_TYPE: ${{ github.event.inputs.build_type }}
           GITHUB_INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          chmod +x linux_build_rando.sh write_version.sh
           ./linux_build_rando.sh
       
       - name: Create QR codes

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/z3dr/randotools:next
-      options: --user 1001
 
     steps:
       - name: Checkout Project

--- a/.github/workflows/create-build.yml
+++ b/.github/workflows/create-build.yml
@@ -1,5 +1,12 @@
 name: MM3DR Build Script
 
+env:
+  # These are used automatically by git
+  GIT_AUTHOR_NAME: ${{ github.actor }}
+  GIT_AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub Actions
+  GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,21 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Get Last Nightly Commit and Private Key
         id: nightly-version
         run: |
-          if [[ ${{ github.event.inputs.build_type == 'Nightly' }} == true ]]; then
-            echo "last_nightly=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
-          else
-            echo "last_nightly=$(git describe --tags --match="v[0-9]*" HEAD --abbrev=0)" >> $GITHUB_ENV
-          fi
-          
+          echo "last_nightly=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
       - name: Generate changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.3.1
+        uses: metcalfc/changelog-generator@v4.7.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ env.last_nightly }}
@@ -46,77 +48,73 @@ jobs:
     needs: get-changelog
     name: Build CIA and 3DSX Files
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     container:
-      image: ghcr.io/z3dr/randotools:next
-      options: --user 1001
+      image: ghcr.io/z3dr/randotools:latest
 
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
-
-      - if: ${{ github.event.inputs.build_type == 'Nightly' }}
-        name: Run Build Script Nightly
+      
+      - name: Run Build Script
+        env:
+          GITHUB_BUILD_TYPE: ${{ github.event.inputs.build_type }}
+          GITHUB_INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          chmod +x linux_build_rando.sh
+          chmod +x linux_build_rando.sh write_version.sh
           ./linux_build_rando.sh
       
-      - if: ${{ github.event.inputs.build_type == 'Release' }}
-        name: Run Build Script Release
-        env:
-          url_tag: v${{ github.event.inputs.version }}
+      - name: Create QR codes
         run: |
-          chmod +x linux_build_rando.sh
-          ./linux_build_rando.sh
+          qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/${{ env.tag_name }}/MM3D_Randomizer.cia
+          qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/${{ env.tag_name }}/MM3D_Randomizer.3dsx
 
-      - name: Get shorthand commit.
-        id: vars
-        run: echo "sha_short=$(echo ${{ github.sha }} | cut -c1-6)" >> $GITHUB_ENV
 
       - if: ${{ github.event.inputs.build_type == 'Nightly' }}
         name: Create Pre-release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "MM3D_Randomizer.cia,MM3D_Randomizer.3dsx,cia.png,3dsx.png"
           prerelease: true
           commit: "${{ github.sha }}"
-          tag: "Nightly-${{ env.sha_short }}"
-          name: "Nightly-${{ env.sha_short }}"
+          tag: "${{ env.tag_name }}"
+          name: "${{ env.tag_name }}"
           body: |
             Please note that these are DEVELOPMENT builds and may not be entirely stable.
             When reporting issues, please mention the six character commit listed in the randomizer menu.
             You can use the FBI homebrew application to install the randomizer using either of these QR codes.
             CIA QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/cia.png)
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/cia.png)
             3DSX QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/Nightly-${{ env.sha_short }}/3dsx.png)
+            ![3DSX Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/3dsx.png)
 
-            Changes Since [${{ needs.get-changelog.outputs.last-nightly }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.get-changelog.outputs.last-nightly }}) 🛠:  
+            Changes Since [${{ needs.get-changelog.outputs.last-nightly }}](https://github.com/${{ github.repository }}/releases/tag/${{ needs.get-changelog.outputs.last-nightly }}) 🛠:
             ${{ needs.get-changelog.outputs.changelog }}
-
 
       - if: ${{ github.event.inputs.build_type == 'Release' }}
         name: Create Release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           artifacts: "MM3D_Randomizer.cia,MM3D_Randomizer.3dsx,cia.png,3dsx.png"
           prerelease: false
           commit: "${{ github.sha }}"
-          tag: "v${{ github.event.inputs.version }}"
-          name: "v${{ github.event.inputs.version }}"
+          tag: "${{ env.tag_name }}"
+          name: "${{ env.tag_name }}"
           body: |
-            ${{ github.event.inputs.version }} Changes 🛠:  
-            ${{ needs.get-changelog.outputs.changelog }}
-            
+            ${{ github.event.inputs.version }} Changes:
+            - Please check back later for a full list of changes.
+
             When reporting issues, please mention the six character commit listed in the randomizer menu.
             You can use the FBI homebrew application to install the randomizer using either of these QR codes.
             CIA QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version }}/cia.png)
+            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/cia.png)
             3DSX QR Code:
-            ![CIA Download](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version }}/3dsx.png)
+            ![3DSX Download](https://github.com/${{ github.repository }}/releases/download/${{ env.tag_name }}/3dsx.png)
 
   deploy-gist:
     needs: build-cia-3dsx
@@ -449,9 +447,16 @@ jobs:
           done
 
       - name: Deploy to Gist
-        uses: exuanbo/actions-deploy-gist@v1.1.4
-        with:
-          token: ${{ secrets.TOKEN }}
-          gist_id: a0bb911772800a7071eddf6298ff6e9f
-          gist_file_name: MM3DR.unistore
-          file_path: ./MM3DR.unistore
+        env:
+          GIST_ID: a0bb911772800a7071eddf6298ff6e9f
+          GIST_FILE_NAME: MM3DR.unistore
+          GIST_ACCESS_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          git clone https://$GIST_ACCESS_TOKEN@gist.github.com/$GIST_ID.git gist
+          cp ./$GIST_FILE_NAME ./gist/
+          cd gist
+          git add --all
+          if ! git diff --cached --quiet; then
+            git commit -m "Update UniStore"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,6 @@ oldcode/loader/build
 *.pyc
 *.ips
 *.zar
-source/include/version.hpp
+source/version.hpp
 source/include/patch_symbols.hpp
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ oldcode/loader/build
 *.pyc
 *.ips
 *.zar
+source/include/version.hpp
 source/include/patch_symbols.hpp
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
 $(BUILD):
 	@git submodule update --init
 	$(MAKE) -C Z3DR/code/
+	@$(TOPDIR)/write_version.sh
 	@mv Z3DR/code/basecode.ips $(ROMFS)/basecode.ips
 	@mv Z3DR/code/basecode1.1.ips $(ROMFS)/basecode1.1.ips
 	@mv Z3DR/source/patch_symbols.hpp $(CURDIR)/source/include/

--- a/linux_build_rando.sh
+++ b/linux_build_rando.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
-
+set -e
 compile() {
   # If building manually just replace SHA with your own text.
   APP_NAME=$(basename "$PWD")
   BANNERTOOLAPP=bannertool
-  IS_GH_ACTIONS=true
-  if [ -n "$GITHUB_SHA" ]; then
-    echo "Building on Github Actions..."
-  else
-    echo "GITHUB_SHA is empty, building locally."
-    IS_GH_ACTIONS=false
-    GITHUB_SHA=$(echo $(git rev-parse --short HEAD))
-  fi
   if ! command -v bannertoolexec &> /dev/null; then
       if ! command -v bannertool &> /dev/null; then
         echo "Bannertool not found in PATH. Please ensure it is in your path before continuing."
@@ -34,23 +26,11 @@ compile() {
     exit 1
   fi
 
-  export commitHashShort=$(echo ${GITHUB_SHA::6})
-  sed -i "s/develop/${commitHashShort:-develop}/" ./source/include/version.hpp
   make -j
-  sed -i "s/${commitHashShort}/develop/" ./source/include/version.hpp
   $BANNERTOOLAPP makebanner -i ./banner.png -a ./audio.wav -o ./banner.bnr
   $BANNERTOOLAPP makesmdh -s "Majora's Mask 3D Randomizer" -l "A Randomized Majoras Mask Experience" -p "Z3DR Team" -i icon.png -o ./icon.icn
   3dstool -cvtf romfs ./romfs.bin --romfs-dir ./romfs
   makerom -f cia -o ${APP_NAME}.cia -DAPP_ENCRYPTED=false -target t -exefslogo -elf ./${APP_NAME}.elf -icon ./icon.icn -banner ./banner.bnr -rsf ./mmrando.rsf -romfs ./romfs.bin -major 1 -minor 0 -micro 0
-  if $IS_GH_ACTIONS; then
-    if [[ ${url_tag+x} ]]; then
-      qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/$url_tag/${APP_NAME}.cia
-      qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/$url_tag/${APP_NAME}.3dsx
-    else
-      qrencode -ocia.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$commitHashShort/${APP_NAME}.cia
-      qrencode -o3dsx.png https://github.com/$GITHUB_REPOSITORY/releases/download/Nightly-$commitHashShort/${APP_NAME}.3dsx
-    fi
-  fi
 }
 
 clean_up() {

--- a/source/include/version.hpp
+++ b/source/include/version.hpp
@@ -1,4 +1,0 @@
-#pragma once
-
-#define RANDOMIZER_VERSION "v1.5.0"
-#define COMMIT_NUMBER "develop"

--- a/source/menu.cpp
+++ b/source/menu.cpp
@@ -34,7 +34,7 @@ void PrintTopScreen()
 	consoleSelect(&topScreen);
 	consoleClear();
 	printf("\x1b[2;11H%sMajoras Mask 3D Randomizer%s", MEGANTA, RESET);
-	printf("\x1b[3;18H%s%s-%s%s",MEGANTA, RANDOMIZER_VERSION, COMMIT_NUMBER, RESET);
+	printf("\x1b[3;18H%s%s%s",MEGANTA, RANDOMIZER_VERSION, RESET);
 	printf("\x1b[4;10HA/B/D-pad: Navigate Menu\n");
 	printf("			Select: Exit to Homebrew Menu\n");
 	printf("				 Y: New Random Seed\n");

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -22,7 +22,7 @@ using namespace game::pad;
 
 namespace Settings {
   std::string seed;
-  std::string version = RANDOMIZER_VERSION "-" COMMIT_NUMBER;
+  std::string version = RANDOMIZER_VERSION;
   std::array<u8, 5> hashIconIndexes;
 
 

--- a/source/version.hpp
+++ b/source/version.hpp
@@ -1,1 +1,0 @@
-#define RANDOMIZER_VERSION "dev-24dc60*"

--- a/source/version.hpp
+++ b/source/version.hpp
@@ -1,0 +1,1 @@
+#define RANDOMIZER_VERSION "dev-24dc60*"

--- a/write_version.sh
+++ b/write_version.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script creates the name for the release git tag and the version string to show in the randomizer menu.
+# It generates a header file with a macro for the version string.
+
+VERSION_FILE="source/version.hpp"
+
+if [[ -n $GITHUB_ENV ]]
+then
+    # Building from GitHub Actions
+    # GITHUB_BUILD_TYPE and GITHUB_INPUT_VERSION are defined in `create_build.yml`
+
+    if [[ "$GITHUB_BUILD_TYPE" = "Release" ]]
+    then
+        VERSION="v$GITHUB_INPUT_VERSION"
+    else
+        VERSION="$GITHUB_BUILD_TYPE-${GITHUB_SHA::6}"
+    fi
+    echo "tag_name=$VERSION" >> $GITHUB_ENV
+else
+    # Building locally
+    VERSION=dev-$(git show --no-patch --format=format:"%h" --abbrev=6)
+
+    # If there are uncommitted changes, add a `*` to the version.
+    if [[ -n $(git status --porcelain) ]]
+    then
+        VERSION="${VERSION}*"
+    fi
+fi
+
+# If the version string doesn't change, don't rewrite the file to avoid useless rebuilds.
+NEW_CONTENT="#define RANDOMIZER_VERSION \"$VERSION\""
+OLD_CONTENT="$(cat "$VERSION_FILE" 2> /dev/null || true)"
+if [[ "$NEW_CONTENT" != "$OLD_CONTENT" ]]
+then
+    echo "$NEW_CONTENT" > "$VERSION_FILE"
+    echo "Wrote version string: $VERSION"
+fi


### PR DESCRIPTION
Also adjusted how the version shows on the app and patch side to fall in line with versioning on the OoT3D_Randomizer side. 

This also includes subrepo updates which changes can be found here https://github.com/Z3DR/mm3dr/pull/127