### PR TITLE
fix: place Song of Time before removing songs from item pool

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -874,12 +874,12 @@ int Fill() {
         RandomizeDungeonItems();
 
         CitraPrint("Trying to place songs");
-
         //Place Songs before inventory to prevent song locations from being used
-        //get Songs in pool
-        std::vector<ItemKey> songs = FilterAndEraseFromPool(ItemPool, [](const ItemKey i) {return ItemTable(i).GetItemType() == ITEMTYPE_SONG;});
+        
         //If Shuffled in Song Locations restrict location pool to only song locations
         //If Song of Time is shuffled do that first with a restricted location pool to prevent softlocks
+        //Also makes sure that Song of Time isn't fitered out of the pool by building the songs vector
+        //first as was done in older versions
         if (ShuffleSongOfTime) {
             std::vector<LocationKey> ocarinaLocations = FilterFromPool(allLocations, []( const LocationKey loc) {return Location(loc)->IsCategory(Category::cNoOcarinaStart);});
             std::vector<ItemKey> SoTItem = FilterAndEraseFromPool(ItemPool, [](const ItemKey i) { return ItemTable(i).GetHintKey() == SONG_OF_TIME; });
@@ -897,6 +897,11 @@ int Fill() {
             AssumedFill(ocarinaItem, ocarinaLocations, true);
             NoRepeatOnTokens = false;
         }
+        
+        //get Songs in pool after placing Song of Time so it doesn't get placed
+        //in a location outside the cNoOcarinaStart category
+        std::vector<ItemKey> songs = FilterAndEraseFromPool(ItemPool, [](const ItemKey i) {return ItemTable(i).GetItemType() == ITEMTYPE_SONG;});
+
         //If Songs are at song locations get all song locations and place them there
         if (ShuffleSongs.Value<u8>() == u8(1)){
             std::vector<LocationKey> songLocations = FilterFromPool(allLocations, [](const LocationKey loc) {return Location(loc)->IsCategory(Category::cSong);});


### PR DESCRIPTION
`fill.cpp` originally built the songs vector on line 880 using `FilterAndEraseFromPool()`. This led to the Song of Time being removed from the item pool prior to the block beginning on line 883 that was intended to place it in a location within a subset of locations considered reachable during first cycle. This PR moves the building of the songs vector to line 903, after the placing of the Song of Time and Ocarina of Time, immediately before placing other songs, in order to ensure the Song of Time is placed in a valid location.