### PR TITLE
Sot first cylce fix

### DIFF
--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -808,9 +808,9 @@ int VanillaFill() {
     //Finish up
     GeneratePlaythrough();
     printf("Done");
-    printf("\x1b[9;10HCalculating Playthrough..."); 
+    printf("\x1b[9;10HCalculating Playthrough...                        "); 
     PareDownPlaythrough();
-    printf("Done                                    ");
+    printf("Done");
     printf("\x1b[10;10HCalculating Way of the Hero..."); 
     CalculateWotH();
     printf("Done");
@@ -841,9 +841,9 @@ int NoLogicFill() {
     FastFill(remainingPool, GetAllEmptyLocations(), false);
     GeneratePlaythrough();
     printf("Done");
-    printf("\x1b[9;10HCalculating Playthrough..."); 
+    printf("\x1b[9;10HCalculating Playthrough...                        "); 
     PareDownPlaythrough();
-    printf("Done                           ");
+    printf("Done");
     printf("\x1b[10;10HCalculating Way of the Hero..."); 
     CalculateWotH();
     printf("Done");
@@ -1134,9 +1134,9 @@ int Fill() {
         //Successful placement, produced beatable result
         if (!placementFailure && playthroughBeatable ) {
             printf("Done");
-            printf("\x1b[9;10HCalculating Playthrough..."); 
+            printf("\x1b[9;10HCalculating Playthrough...                        "); 
             PareDownPlaythrough();
-            printf("Done                        ");
+            printf("Done");
             printf("\x1b[10;10HCalculating Way of the Hero..."); 
             CalculateWotH();
             printf("Done");

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -25,6 +25,11 @@ using namespace Settings;
 
 static bool placementFailure = false;
 static bool NoRepeatOnTokens = false;
+static int retries = 0;
+
+extern bool ocarinaObtainable;
+extern bool songOfTimeObtainable;
+extern bool playthroughBeatable;
 
 static void RemoveStartingItemsFromPool() {
     for (ItemKey startingItem : StartingInventory) {
@@ -88,11 +93,13 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
     //    PlacementLog_Msg(Location(loc)->GetName() + "\n");
     //}
     //Reset all access to begin a new search
+    playthroughBeatable  = false;
+    ocarinaObtainable    = false;
+    songOfTimeObtainable = false;
+
     ApplyStartingInventory();
-   
     Areas::AccessReset();
     LocationReset();
-
     
     std::vector<AreaKey> areaPool = { ROOT };
     
@@ -206,11 +213,23 @@ std::vector<LocationKey> GetAccessibleLocations(const std::vector<LocationKey>& 
                             itemSphere.push_back(loc);
                             playthroughBeatable = true;
                         }
+                        //Song of Time has been found, the rest of the fill algorithm can be continued now.
+                        if (location->GetPlacedItemKey() == SONG_OF_TIME) {
+                            songOfTimeObtainable = true;
+                        }
                     }
                     //All we care about is if the game is beatable, used to pare down playthrough
-                    else if (location->GetPlacedItemKey() == MAJORAS_MASK && mode == SearchMode::CheckBeatable) {
-                        playthroughBeatable = true;
-                        return {}; //Return early for efficiency
+                    else if (mode == SearchMode::CheckBeatable) {
+                        if (location->GetPlacedItemKey() == MAJORAS_MASK) {
+                            playthroughBeatable = true;
+                            return {}; //Return early for efficiency
+                        }
+                        if (location->GetPlacedItemKey() == OCARINA_OF_TIME) {
+                            ocarinaObtainable = true;
+                        }
+                        if (location->GetPlacedItemKey() == SONG_OF_TIME) {
+                            songOfTimeObtainable = true;
+                        }
                     }
                 }
             }
@@ -523,7 +542,7 @@ static void AssumedFill(const std::vector<ItemKey>& items, const std::vector<Loc
 
             //If Tokensanity is on and RepeatableItemsOnTokens is off
             //Only place non repeatable items
-            if (NoRepeatOnTokens) {
+            if (Tokensanity && !RepeatableItemsOnTokens) {
                 //If the item is repeatable put it back and try again
                 if (ItemTable(item).IsReusable() ) {
                     CitraPrint("Attempting to place Repeatable Item in SSH/OSH Location");
@@ -845,13 +864,15 @@ int NoLogicFill() {
 int Fill() {
     CustomMessages::CreateBaselineCustomMessages();
 
-    int retries = 0;
+    retries = 0;
     while (retries < 5) {
         placementFailure = false;
         showItemProgress = false;
         playthroughLocations.clear();
         playthroughEntrances.clear();
         wothLocations.clear();
+        ocarinaObtainable = false;
+        songOfTimeObtainable = false;
         AreaTable_Init(); //Reset the world graph to intialize the proper locations
         ItemReset(); //Reset shops incase of shopsanity random
         GenerateLocationPool();
@@ -898,6 +919,101 @@ int Fill() {
             AssumedFill(ocarinaItem, ocarinaLocations, true);
             NoRepeatOnTokens = false;
         }
+        // Ensure Ocarina and Song of Time are obtainable with the current placement.
+        // If they are not reachable with currently placed items (Rewards, Keys, etc.),
+        // we place additional advancement items from the pool to open paths until they are reachable.
+        if ((StartingOcarina.Value<u8>() == 0) || ShuffleSongOfTime) {
+            while (true) {
+                Logic::LogicReset();
+                std::vector<LocationKey> ocarinaLocations = FilterFromPool(allLocations, []( const LocationKey loc) {return Location(loc)->IsCategory(Category::cNoOcarinaStart);});
+                GetAccessibleLocations(ocarinaLocations, SearchMode::CheckBeatable);
+
+                // Check if the requirements for the Ocarina and Song of Time are met.
+                bool needsOcarina = (StartingOcarina.Value<u8>() == 0 && !ocarinaObtainable);
+                bool needsSoT     = (ShuffleSongOfTime && !songOfTimeObtainable);
+                CitraPrint("Checking if Ocarina and Song of Time are reachable with current placements...");
+                CitraPrint(needsOcarina ? "Ocarina is not reachable." : "Ocarina is reachable.");
+                CitraPrint(needsSoT ? "Song of Time is not reachable." : "Song of Time is reachable.");
+                DebugPrint("%s: needsOcarina=%d, needsSoT=%d\n", __func__, needsOcarina, needsSoT);
+
+                if (!needsOcarina && !needsSoT) {
+                    break; // Critical items are reachable with current world state.
+                }
+
+                // Find items that actually help reach the Ocarina or Song of Time.
+                std::vector<ItemKey> advancementPool = FilterFromPool(ItemPool, [](const ItemKey i) {
+                  return ItemTable(i).IsAdvancement() && ItemTable(i).GetItemType() != ITEMTYPE_QUEST;
+                });
+
+                if (advancementPool.empty()) {
+                  placementFailure = true;
+                  break;
+                }
+
+                std::vector<ItemKey> usefulHelpers;
+                for (ItemKey candidate : advancementPool) {
+                  Logic::LogicReset();
+                  ItemTable(candidate).ApplyEffect();
+                  GetAccessibleLocations(ocarinaLocations, SearchMode::CheckBeatable);
+
+                  if ((needsOcarina && ocarinaObtainable) || (needsSoT && songOfTimeObtainable)) {
+                    usefulHelpers.push_back(candidate);
+                  }
+                  ItemTable(candidate).UndoEffect();
+                }
+
+                ItemKey itemToHelp = NONE;
+                if (!usefulHelpers.empty()) {
+                  itemToHelp = RandomElement(usefulHelpers);
+                } else {
+                  // If no single item helps, find items that unlock NEW locations (logic expansion).
+                  Logic::LogicReset();
+                  size_t currentCount = GetAccessibleLocations(ocarinaLocations).size();
+
+                  std::vector<std::pair<ItemKey, size_t>> progressItems;
+                  for (ItemKey candidate : advancementPool) {
+                    Logic::LogicReset();
+                    ItemTable(candidate).ApplyEffect();
+                    size_t newCount = GetAccessibleLocations(ocarinaLocations).size();
+                    if (newCount > currentCount) {
+                      progressItems.push_back({candidate, newCount});
+                    }
+                    ItemTable(candidate).UndoEffect();
+                  }
+
+                  if (!progressItems.empty()) {
+                    std::sort(progressItems.begin(), progressItems.end(), [](auto a, auto b) { return a.second > b.second; });
+                    itemToHelp = progressItems[0].first;
+                  }
+                }
+
+                if (itemToHelp == NONE) {
+                  placementFailure = true;
+                  break;
+                }
+
+                auto it = std::find(ItemPool.begin(), ItemPool.end(), itemToHelp);
+                if (it != ItemPool.end()) {
+                  ItemPool.erase(it);
+                }
+
+                NoRepeatOnTokens = true;
+                AssumedFill({itemToHelp}, ocarinaLocations, true);
+                NoRepeatOnTokens = false;
+                if (placementFailure) break;
+            }
+        }
+
+        if (placementFailure) {
+            if (retries < 4) {
+                printf("\x1b[9;10HEarly Item Reachability Failed. Retrying... %d", retries + 2);
+                Areas::ResetAllLocations();
+                Logic::LogicReset();
+            }
+            retries++;
+            continue;
+        }
+        CitraPrint("Successfully placed Ocarina and Song of Time (if shuffled). Continuing with item placement...");
         //If Songs are at song locations get all song locations and place them there
         if (ShuffleSongs.Value<u8>() == u8(1)){
             std::vector<LocationKey> songLocations = FilterFromPool(allLocations, [](const LocationKey loc) {return Location(loc)->IsCategory(Category::cSong);});

--- a/source/fill.cpp
+++ b/source/fill.cpp
@@ -810,7 +810,7 @@ int VanillaFill() {
     printf("Done");
     printf("\x1b[9;10HCalculating Playthrough..."); 
     PareDownPlaythrough();
-    printf("Done");
+    printf("Done                                    ");
     printf("\x1b[10;10HCalculating Way of the Hero..."); 
     CalculateWotH();
     printf("Done");
@@ -843,7 +843,7 @@ int NoLogicFill() {
     printf("Done");
     printf("\x1b[9;10HCalculating Playthrough..."); 
     PareDownPlaythrough();
-    printf("Done");
+    printf("Done                           ");
     printf("\x1b[10;10HCalculating Way of the Hero..."); 
     CalculateWotH();
     printf("Done");
@@ -909,7 +909,7 @@ int Fill() {
             AssumedFill(SoTItem, ocarinaLocations, true);
             NoRepeatOnTokens = false;
         }
-        //If Ocarina is shuffled place that first 
+        //If Ocarina is shuffled place that next
         if (StartingOcarina.Value<u8>() == 0) {
             //Get acceptable Ocarina Locations
             std::vector<LocationKey> ocarinaLocations = FilterFromPool(allLocations, []( const LocationKey loc) {return Location(loc)->IsCategory(Category::cNoOcarinaStart);});
@@ -1136,7 +1136,7 @@ int Fill() {
             printf("Done");
             printf("\x1b[9;10HCalculating Playthrough..."); 
             PareDownPlaythrough();
-            printf("Done");
+            printf("Done                        ");
             printf("\x1b[10;10HCalculating Way of the Hero..."); 
             CalculateWotH();
             printf("Done");

--- a/source/hint_list.cpp
+++ b/source/hint_list.cpp
@@ -331,7 +331,7 @@ void HintTable_Init() {
     );
     hintTable[GIANTS_MASK] = HintText::Item({
             //obscure
-            Text{"a growth spur", "une poussée de croissance", "un súbito crecimiento"}
+            Text{"a growth spurt", "une poussée de croissance", "un súbito crecimiento"}
         },  //clear
             Text{"the Giant's Mask", "le masque du géant", "la Máscara del gigante"}
     );

--- a/source/include/setting_descriptions.hpp
+++ b/source/include/setting_descriptions.hpp
@@ -246,3 +246,4 @@ extern string_view startingSwordGildedDesc;
 extern string_view startingShieldNoneDesc;
 extern string_view startingShieldHerosDesc;
 extern string_view startingShieldMirrorDesc;
+extern string_view showPostmanItemDesc;

--- a/source/item_location.cpp
+++ b/source/item_location.cpp
@@ -1071,6 +1071,8 @@ std::set<ItemOverride, ItemOverride_Compare> overrides = {};
 std::vector<std::vector<LocationKey>> playthroughLocations;
 std::vector<LocationKey> wothLocations;
 bool playthroughBeatable = false;
+bool ocarinaObtainable = false;
+bool songOfTimeObtainable = false;
 bool allLocationsReachable = false;
 bool showItemProgress = false;
 

--- a/source/location_access.cpp
+++ b/source/location_access.cpp
@@ -596,8 +596,8 @@ void AreaTable_Init() {
 	},
 	{
 		//Exits
-		Entrance(S_CLOCK_TOWN, {[]{return true;}}),
-		Entrance(THE_MOON_TREE_ROOM, {[]{return CanGoToMoon && CanPlay(SongOfTime);}}),
+		Entrance(S_CLOCK_TOWN, {[]{return SongOfTime;}}),
+		Entrance(THE_MOON_TREE_ROOM, {[]{return CanGoToMoon && SongOfTime;}}),
 	});
 
 	areaTable[LAUNDRY_POOL] = Area("Laundry Pool", "Laundry Pool", LAUNDRY_POOL, {
@@ -3725,7 +3725,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Exits
-		Entrance(S_CLOCK_TOWN, {[]{return true;}}),
+		Entrance(S_CLOCK_TOWN, {[]{return CanPlay(SongOfTime);}}),
 		Entrance(THE_MOON_BOSS_ROOM, {[]{return RemainsForMajora;}}),
 		Entrance(THE_MOON_DEKU_TRIAL, {[]{return (TotalMaskCount() >= 1);}}),
 		Entrance(THE_MOON_GORON_TRIAL, {[]{return (TotalMaskCount() >= 2);}}),
@@ -3947,7 +3947,7 @@ void AreaTable_Init() {
 	},
 	{
 		//Exits
-		Entrance(S_CLOCK_TOWN, {[]{return true;}}),//just play SoT
+		Entrance(S_CLOCK_TOWN, {[]{return CanPlay(SongOfTime);}}),//just play SoT
 	});
 
 

--- a/source/logic.cpp
+++ b/source/logic.cpp
@@ -684,6 +684,7 @@ namespace Logic {
 	  OathToOrder = false;
 	  EponasSong = false;
 	  SongOfSoaring = false;
+	  SongOfTime = false;
 	//Remains
 	  OdolwaRemains = false;
 	  GohtRemains = false;

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -512,11 +512,11 @@ string_view shuffleCowsDesc           = "**OPTION CURRENTLY WIP**\n"            
 /*------------------------------                                                           //
 |       SHUFFLE OCARINAS       |                                                           //
 ------------------------------*/                                                           //
-string_view ocarinasDesc              = "Setting this to None shuffles the Ocarina of Time\n"//
+string_view ocarinasDesc              = "Setting this to No shuffles the Ocarina of Time\n"//
                                         "into the item pool."     					       //
                                         "\n"                                               //
                                         "This will require finding an Ocarina before being\n"
-                                        "able to play songs. or restart the days";         //
+                                        "able to play songs or restart the cycle";         //
 
 /*------------------------------                                                           //
 |        FREE SCARECROW        |                                                           //

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -557,16 +557,15 @@ string_view chestSizeDesc             = "This option will change the appearance 
 /*------------------------------                                                           //
 |         COLORED KEYS         |                                                           //
 ------------------------------*/                                                           //
-string_view coloredKeysDesc           = "**OPTION CURRENTLY WIP**\n"                       //
-                                        "If set, small key models will be colored\n"       //
-                                        "differently depending on which dungeon they can be"
-                                        "used in. Forest Temple keys are green. Fire Temple"
-                                        "keys are red. etc.";                              //
+string_view coloredKeysDesc           = "If set, small key models will be colored\n"       //
+                                        "differently depending on which dungeon they\n"    //
+                                        "can be used in. Woodfall Temple keys are green.\n"//
+                                        "Snowhead Temple keys are pink. etc.";             //
 string_view coloredBossKeysDesc       = "**OPTION CURRENTLY WIP**\n"                       //
                                         "If set, boss key models will be colored\n"        //
                                         "differently depending on which dungeon they can be"
-                                        "used in. The Forest Temple boss key is green. The "
-                                        "Fire Temple boss key is red. etc.";               //
+                                        "used in. The Woodfall Temple boss key is green. The "
+                                        "Snowhead Temple boss key is pink. etc.";          //
 /*------------------------------                                                           //
 |        SHUFFLE MUSIC         |                                                           //
 ------------------------------*/                                                           //
@@ -697,5 +696,6 @@ string_view startingShieldMirrorDesc  = "Start with the Mirror Shield.\n"       
 /*------------------------------                                                           //
 |       POSTMAN HAT            |                                                           //
 ------------------------------*/                                                           //
-string_view showPostmanItemDesc      = "If set, the Postman's Hat model will be replaced \n"//
-                                        "with the item model of the randomized item.";     //
+string_view showPostmanItemDesc      = "Visually shows the reward for the \n"              //
+                                       "Postman's Freedom quest line \n"                   //
+                                       "above the Postman's head.";                        //

--- a/source/setting_descriptions.cpp
+++ b/source/setting_descriptions.cpp
@@ -694,3 +694,8 @@ string_view startingShieldHerosDesc   = "Start with the Hero's Shield.\n"       
 string_view startingShieldMirrorDesc  = "Start with the Mirror Shield.\n"                    //
                                         "Starting with the Mirror Shield will not add any \n"//
                                         "additional shields to the item pool.";            //
+/*------------------------------                                                           //
+|       POSTMAN HAT            |                                                           //
+------------------------------*/                                                           //
+string_view showPostmanItemDesc      = "If set, the Postman's Hat model will be replaced \n"//
+                                        "with the item model of the randomized item.";     //

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -568,6 +568,7 @@ namespace Settings {
 
   Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"}, {coloredKeysDesc}, OptionCategory::Cosmetic);
   Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"}, {coloredBossKeysDesc},  OptionCategory::Cosmetic);
+  Option ShowPostmanItem = Option::Bool("Show Postman Item", {"Off", "On"}, {showPostmanItemDesc}, OptionCategory::Cosmetic);
 
   static std::vector<std::string> fanfareOptions = {"Off", "Only Fanfares", "Fanfares +\n                         Ocarina Music"};
   static std::vector<std::string_view> fanfareDescriptions = {fanfaresOffDesc, onlyFanfaresDesc, fanfaresOcarinaDesc};
@@ -579,14 +580,15 @@ namespace Settings {
   
 //TO-DO Heart Color, Magic Color, Tatl Color
   std::vector<Option *> cosmeticOptions = {
-    &CustomTunicColors,
-    &ChildTunicColor,
+    //&CustomTunicColors,
+    //&ChildTunicColor,
     &ColoredKeys,
-    &ColoredBossKeys,
- //   &ShuffleMusic,
- //   &ShuffleBGM,
- //   &ShuffleFanfares,
- //   &ShuffleOcaMusic,
+    //&ColoredBossKeys,
+    &ShowPostmanItem,
+    //&ShuffleMusic,
+    //&ShuffleBGM,
+    //&ShuffleFanfares,
+    //&ShuffleOcaMusic,
   };
 
  
@@ -673,7 +675,7 @@ namespace Settings {
     &cutsceneSettings,
     &otherSettings,
     &customInputs,
-    //&cosmetics,
+    &cosmetics,
     &settingsPresets,
     &generateRandomizer,
   };
@@ -772,6 +774,7 @@ namespace Settings {
     ctx.customTunicColors = (CustomTunicColors) ? 1 : 0;
     ctx.coloredKeys = (ColoredKeys) ? 1 : 0;
     ctx.coloredBossKeys = (ColoredBossKeys) ? 1 : 0;
+    ctx.showPostmanItem = (ShowPostmanItem) ? 1 : 0;
     //ctx.shuffleMusic = (ShuffleMusic)?1:0;
     //ctx.shuffleBGM = (ShuffleBGM)?1:0;
     //ctx.shuffleFanfare = ShuffleFanfares.Value<u8>();

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -568,7 +568,7 @@ namespace Settings {
 
   Option ColoredKeys =     Option::Bool("Colored Small Keys", {"Off", "On"}, {coloredKeysDesc}, OptionCategory::Cosmetic);
   Option ColoredBossKeys = Option::Bool("Colored Boss Keys",  {"Off", "On"}, {coloredBossKeysDesc},  OptionCategory::Cosmetic);
-  Option ShowPostmanItem = Option::Bool("Show Postman Item", {"Off", "On"}, {showPostmanItemDesc}, OptionCategory::Cosmetic);
+  Option ShowPostmanItem = Option::U8("Show Postman Item", {"Off", "On"}, {showPostmanItemDesc}, OptionCategory::Cosmetic);
 
   static std::vector<std::string> fanfareOptions = {"Off", "Only Fanfares", "Fanfares +\n                         Ocarina Music"};
   static std::vector<std::string_view> fanfareDescriptions = {fanfaresOffDesc, onlyFanfaresDesc, fanfaresOcarinaDesc};

--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -113,7 +113,7 @@ namespace Settings {
   Option StartingMaxRupees         = Option::Bool("Start with Max Rupees",  { "No",               "Yes" },                                                     { startWithMaxRupeesDesc });
   Option StartingInventoryToggle   = Option::U8("Inventory",                { "All Off",          "All On",           "Choose" },                              { "" });
   Option StartingNutCapacity       = Option::U8("Deku Nuts",                { "None",             "20 Deku Nuts",     "30 Deku Nuts",     "40 Deku Nuts" },    { "" });
-  Option StartingOcarina           = Option::U8("Shuffle Ocarina",        { "No",  "Yes" },                                                                 { ocarinasDesc }, OptionCategory::Setting, 1);
+  Option StartingOcarina           = Option::U8("Start With Ocarina",     { "No",  "Yes" },                                                                 { ocarinasDesc }, OptionCategory::Setting, 1);
   Option StartingNotebook          = Option::U8("Bomber's Notebook",      { "None",             "B. Notebook"},                                              { "" });
   Option StartingBombBag           = Option::U8("Bomb Bag",               { "None",             "Bomb Bag 20",      "Bomb Bag 30",      "Bomb Bag 40" },     { "" });
   Option StartingBombchus          = Option::U8("Bombchus",               { "None",             "Bombchus" },                                                { "" });


### PR DESCRIPTION
- Add missing SongOfTime variable to LogicReset function to fix functionality
- Adds setting to show the Postman's Hat reward instead of the Postman's Hat on the Postman's Head
- Adds Colored Keys setting and adds a new setting for the Postmans Hat
- Adds functionality similar to playthroughBeatable to ensure that (when shuffled) Ocarina and/or Song of Time are obtainable within the first cycle by making sure that the items needed to reach their randomized locations are also reachable within the same restricted location pool
- Fixes Description for Shuffle Ocarina to clarify what the setting actually does.
- Fixes English Giant's Mask hint text
