### PR TITLE
Add EndType to createMessage

### DIFF
--- a/source/custom_messages.cpp
+++ b/source/custom_messages.cpp
@@ -30,7 +30,7 @@ u32 pushText(const char* data) {
 
 void CreateMessage(u16 textId, u16 field_2, u32 field_4, u32 flags, const Language& text,
                    const std::vector<colType>& cols, const std::vector<iconType>& icons, const std::vector<u8>& delays,
-                   u16 sfx, bool instant, bool repeatSfx) {
+                   u16 sfx, bool instant, bool repeatSfx, u8 messageEndType) {
 #ifdef ENABLE_DEBUG
     static std::vector<u16> usedTextIds;
     if (messageEntries.empty()) {
@@ -48,8 +48,8 @@ void CreateMessage(u16 textId, u16 field_2, u32 field_4, u32 flags, const Langua
     newEntry.id = textId;
     newEntry.field_2 = field_2;
     newEntry.field_4 = field_4;
-    newEntry.flags = flags;
-    newEntry.sfxAndFlags = ((instant) ? 0x8000 : 0x0000) | ((repeatSfx) ? 0x4000 : 0x0000) | sfx;
+    newEntry.flags = (flags & 0xFFFFFF) | (messageEndType << 24);
+    newEntry.sfxAndFlags = (sfx & 0x0FFF) | (instant << 15) | (repeatSfx << 14);
 
     u32 offsetNaEn = 0, offsetNaFr = 0, offsetNaEs = 0, offsetEuEn = 0, offsetEuFr = 0, offsetEuEs = 0, offsetEuDe = 0, offsetEuIt = 0, offsetJpJp = 0;
     u32 offsetCol = 0, offsetIcon = 0, offsetDelay = 0;
@@ -181,7 +181,7 @@ void CreateMessage(u16 textId, u16 field_2, u32 field_4, u32 flags, const Langua
 
 void CreateMessageFromTextObject(u16 textId, u16 field_2, u32 field_4, u32 flags, const Text& text,
                    const std::vector<colType>& cols, const std::vector<iconType>& icons, const std::vector<u8>& delays,
-                   u16 sfx, bool instant, bool repeatSfx) {
+                   u16 sfx, bool instant, bool repeatSfx, u8 messageEndType) {
     CreateMessage(textId, field_2, field_4, flags,
                 //      NaEnglish                     NaFrench                      NaSpanish
                   {text.GetNAEnglish().c_str(), text.GetNAFrench().c_str(), text.GetNASpanish().c_str(),
@@ -190,7 +190,7 @@ void CreateMessageFromTextObject(u16 textId, u16 field_2, u32 field_4, u32 flags
                 text.GetEUREnglish().c_str(), text.GetEUREnglish().c_str(), // text.GetNAEnglish().c_str(),
                 //      EuEnglish                     EuFrench                      EuSpanish
                 text.GetEUREnglish().c_str(), text.GetEURFrench().c_str(), text.GetEURSpanish().c_str()
-                }, cols, icons, delays, sfx, instant, repeatSfx);
+                }, cols, icons, delays, sfx, instant, repeatSfx, messageEndType);
 }
 
 void CreateBaselineCustomMessages() {
@@ -241,82 +241,82 @@ void CreateBaselineCustomMessages() {
     // Woodfall
     CreateMessageFromTextObject(0x6133, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroSKey + GITextDungeonWoodfall + GITextOutroSKey,
-        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
     // Snowhead
     CreateMessageFromTextObject(0x6134, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroSKey + GITextDungeonSnowhead + GITextOutroSKey,
-        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
     // Great Bay
     CreateMessageFromTextObject(0x6135, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroSKey + GITextDungeonGreatBay + GITextOutroSKey,
-        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
     // Stone Tower
     CreateMessageFromTextObject(0x6136, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroSKey + GITextDungeonStoneTower + GITextOutroSKey,
-        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Maps
     // Woodfall
     CreateMessageFromTextObject(0x6137, 0x003E, 0x3FFFFFFF, 0xFF0000,
         GITextIntroMap + GITextDungeonWoodfall,
-        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Snowhead
     CreateMessageFromTextObject(0x6138, 0x003E, 0x3FFFFFFF, 0xFF0000,
         GITextIntroMap + GITextDungeonSnowhead,
-        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Great Bay
     CreateMessageFromTextObject(0x6139, 0x003E, 0x3FFFFFFF, 0xFF0000,
         GITextIntroMap + GITextDungeonGreatBay,
-        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Stone Tower
     CreateMessageFromTextObject(0x613A, 0x003E, 0x3FFFFFFF, 0xFF0000,
         GITextIntroMap + GITextDungeonStoneTower,
-        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Compasses
     // Woodfall
     CreateMessageFromTextObject(0x613B, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroCompass + GITextDungeonWoodfall + GITextOutroCompass,
-        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Snowhead
     CreateMessageFromTextObject(0x613C, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroCompass + GITextDungeonSnowhead + GITextOutroCompass,
-        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_MAGENTA}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Great Bay
     CreateMessageFromTextObject(0x613D, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroCompass + GITextDungeonGreatBay + GITextOutroCompass,
-        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_CYAN}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Stone Tower
     CreateMessageFromTextObject(0x613E, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroCompass + GITextDungeonStoneTower + GITextOutroCompass,
-        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_YELLOW}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Boss Keys
     // Woodfall
     CreateMessageFromTextObject(0x613F, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroBKey + GITextDungeonWoodfall + GITextOutroBKey,
-        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Snowhead
     CreateMessageFromTextObject(0x6140, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroBKey + GITextDungeonSnowhead + GITextOutroBKey,
-        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Great Bay
     CreateMessageFromTextObject(0x6141, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroBKey + GITextDungeonGreatBay + GITextOutroBKey,
-        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Stone Tower
     CreateMessageFromTextObject(0x6142, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         GITextIntroBKey + GITextDungeonStoneTower + GITextOutroBKey,
-        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+        {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Kokiri Sword
     CreateMessage(0x0037, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
@@ -324,7 +324,7 @@ void CreateBaselineCustomMessages() {
         // French
         "Vous obtenez l'#épée Kokiri#! Votre fidèle épée qui provient de le forêt Kokiri.",
     },
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     // Ice Trap
     CreateMessage(0x0012, 0xFFFF, 0x3FFFFFFF, 0xFF0000, 
@@ -332,7 +332,7 @@ void CreateBaselineCustomMessages() {
         // French
         "#IDIOT!#",
     },
-    {QM_RED}, {}, {}, 0x0, false, false);
+    {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     //Swamp Skulltula Tokens
     CreateMessage(0x0052, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
@@ -340,7 +340,7 @@ void CreateBaselineCustomMessages() {
         // French
         "Vous obtenez l'#âme d'une skulltula d'or des marais#!&Vous en avez désormais #=SSH#.",
     },
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     //Ocean Skulltula Tokens
     CreateMessage(0x6143, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
@@ -348,7 +348,7 @@ void CreateBaselineCustomMessages() {
         // French
         "Vous obtenez l'#âme d'une skulltula d'or de la côte#!&Vous en avez désormais #=OSH#.",
     },
-    {QM_BLUE, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_BLUE, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     //Bank Rewards
     CreateMessage(0x045c, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
@@ -368,7 +368,7 @@ void CreateBaselineCustomMessages() {
         // EU Spanish
         "¿Qué es esto? ¡¿Ya has ahorrado&#500 rupias#?!^Bien, jovencito. Aquí está tu regalo&especial. ¡Tómalo!",
     },
-    {QM_RED}, {}, {}, 0x0, false, false);
+    {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENT);
 
     CreateMessage(0x045d, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
     {"What's this? You've already&saved up #1,000 Rupees#?!^Well, little guy, I can't take any more deposits. Sorry, but this is all I can give you.",
@@ -387,7 +387,7 @@ void CreateBaselineCustomMessages() {
         // EU Spanish
         "¿Qué es esto? ¡¿Ya has ahorrado&#1000 rupias#?!^Bien, jovencito. No puedo aceptar&más depósitos. Lo siento, pero&esto es todo lo que puedo darte.",
     },
-    {QM_RED}, {}, {}, 0x0, false, false);
+    {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENT);
 
     //Stray Fairies
     CreateMessage(0x06144, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
@@ -395,35 +395,35 @@ void CreateBaselineCustomMessages() {
         // French
         "Vous obtenez une #fée égarée de la ville#! Apportez-la à la fontaine des fées au nord de la ville!",
     },
-    {QM_RED}, {}, {}, 0x0, false, false);
+    {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     CreateMessage(0x06145, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
     {"You got a #Woodfall Stray Fairy#! &You have collected #=WFF#.",
         // French
         "Vous obtenez une #fée égarée des marais#!&Vous en avez désormais #=WFF#.",
     },
-    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     CreateMessage(0x06146, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
     {"You got a #Snowhead Stray Fairy#! &You have collected #=SHF#.",
         // French
         "Vous obtenez une #fée égarée des neiges#!&Vous en avez désormais #=SHF#.",
     },
-    {QM_MAGENTA, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_MAGENTA, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     CreateMessage(0x06147, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
     {"You got a #Great Bay Stray Fairy#! &You have collected #=GBF#.",
         // French
         "Vous obtenez une #fée égarée de la baie#!&Vous en avez désormais #=GBF#.",
     },
-    {QM_BLUE, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_BLUE, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
     CreateMessage(0x06148, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
     {"You got a #Stone Tower Stray Fairy#! &You have collected #=STF#.",
         // French
         "Vous obtenez une #fée égarée d'Ikana#!&Vous en avez désormais #=STF#.",
     },
-    {QM_YELLOW, QM_RED}, {}, {}, 0x0, false, false);
+    {QM_YELLOW, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 
 }
 

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -555,6 +555,15 @@ void CreateOtherHints() {
     // /*Italian?*/"#...^Ma solo se riesci a nuotare&attraverso tutti gli #anelli&#nel fiume #entro 2 minuti#.",
   }, {QM_RED, QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
 
+  // Remove French mention of bottle
+  CustomMessages::CreateMessage(0x10DD, 0xFFFF, 0x3FFFFFFF, 0xFF0000, {
+    /*English*/"Uh... That was perfect.^That's not good...",
+    /*French */"Ooh... Tu as parfaitement réussi...^C'est pas bon...",
+    /*Spanish*/"Eh... Perfecto.^Esto no está bien...",
+    /*German */"Uh... Das war perfekt!^Das ist gar nicht gut...",
+    /*Italian*/"Uh... Sei stato perfetto.^Accidenti...",
+  }, {}, {}, {}, 0x0, false, false, MESSAGE_END_EVENT);
+
   CustomMessages::CreateMessageFromTextObject(0x10E0, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*NaEnglish*/"What?&He wants #",
     /*NaFrench */"Quoi?&Il veut #",
@@ -562,7 +571,7 @@ void CreateOtherHints() {
     // /*EuGerman ?*/"Was?&#",
     // /*EuItalian?*/"Cosa?&#",
     /*EuEnglish*/"",
-    /*EuFrench */"Quoi ?&Il veut#",
+    /*EuFrench */"Quoi ?&Il veut #",
     /*EuSpanish*/"",
   }+beaverBottleHint+Text{
     /*NaEnglish*/"#?",

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -168,7 +168,7 @@ static void AddHint(Text hint, const LocationKey gossipStone, const std::vector<
   if (hint.GetNAEnglish().find("$")) {
     icons.push_back(B_BUTTON);
   }
-  CustomMessages::CreateMessageFromTextObject(messageId, 0xFFFF, 0x3FFFFFFF, 0xFF0020, hint, colors, icons, {}, 0x0, false, false);
+  CustomMessages::CreateMessageFromTextObject(messageId, 0xFFFF, 0x3FFFFFFF, 0xFF0020, hint, colors, icons, {}, 0x0, false, false, MESSAGE_END_NORMAL);
   //CreateMessageFromTextObject(messageId, 0, 2, 3, AddColorsAndFormat(hint, colors));
   //CreateMessageFromTextObject(sariaMessageId, 0, 2, 3, AddColorsAndFormat(hint + EVENT_TRIGGER(), colors));
 }
@@ -457,32 +457,32 @@ void CreateTingleHintText() {
         // Clock Town message
         CustomMessages::CreateMessageFromTextObject(0x1D11, 0xFFFF, 0x3FF0A005, 0xFF1001,
           clockTownMap+priceFive+woodfallMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
 
         // Woodfall message
         CustomMessages::CreateMessageFromTextObject(0x1D12, 0xFFFF, 0x3FF0A014, 0xFF1001,
           woodfallMap+priceTwenty+snowHeadMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
 
         // Snowhead message
         CustomMessages::CreateMessageFromTextObject(0x1D13, 0xFFFF, 0x3FF0A014, 0xFF1001,
           snowHeadMap+priceTwenty+romaniMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
 
         // Milk Road message
         CustomMessages::CreateMessageFromTextObject(0x1D14, 0xFFFF, 0x3FF0A014, 0xFF1001,
           romaniMap+priceTwenty+greatBayMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
 
         // Great Bay message
         CustomMessages::CreateMessageFromTextObject(0x1D15, 0xFFFF, 0x3FF0A014, 0xFF1001,
           greatBayMap+priceTwenty+ikanaMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
 
         // Ikana message
         CustomMessages::CreateMessageFromTextObject(0x1D16, 0xFFFF, 0x3FF0A014, 0xFF1001,
           ikanaMap+priceTwenty+clockTownMap+priceForty+leaveShop,
-          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false);
+          {QM_GREEN, QM_RED, QM_GREEN, QM_RED, QM_GREEN}, {}, {}, 0x0, false, false, MESSAGE_END_NULL);
       }
 }
 
@@ -497,7 +497,7 @@ void CreateOtherHints() {
     // /*German ?*/"Wenn du zum Beispiel #200 Rubine# sparst, gebe ich dir #",
     // /*Italian?*/"Per esempio, se depositi #200 rupie#, otterrai #",
   }+ItemTable(Location(S_CLOCK_TOWN_BANK_REWARD_1)->GetPlacedItemKey()).GetHint().GetText()
-  +"#.", {QM_RED, QM_RED}, {}, {}, 0x0, false, false);
+  +"#.", {QM_RED, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENTNEXT);
 
   //Termina Field Deku Salesman Heart Piece
   CustomMessages::CreateMessageFromTextObject(0x1631, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
@@ -512,7 +512,7 @@ void CreateOtherHints() {
     /*Spanish*/"# si mantiene este lugar en secreto...",
     // /*German ?*/"#, aber bitte behalte dieses Geheimnis für dich!",
     // /*Italian?*/"# se mantieni il segreto su questo posto...",
-  }, {QM_RED}, {}, {}, 0x0, false, false);
+  }, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENTNEXT);
 
   //Beaver Hints
   Text beaverBottleHint = ItemTable(Location(ZORA_CAPE_BEAVER_RACE_1)->GetPlacedItemKey()).GetHint().GetText();
@@ -532,14 +532,14 @@ void CreateOtherHints() {
     /*EuEnglish*/"",
     /*EuFrench */"#, c'est ça ?&Tu ne retiens jamais la leçon !",
     /*EuSpanish*/"",
-  }, {QM_RED}, {}, {}, 0x0, false, false);
+  }, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
   CustomMessages::CreateMessageFromTextObject(0x10D0, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"Koo, koo, koo...&OK. But...",
     /*French */"Kii, kii, kii.&OK. Mais...",
     /*Spanish?*/"Cu, cu, cu.&Muy bien. Pero...",
     // /*German ?*/"Quiek, quiek, quiek!&Okay. Aber...",
     // /*Italian?*/"Uh uh uh.&Va bene. Ma...",
-  }, {}, {}, {}, 0x0, false, false);
+  }, {}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
 
   CustomMessages::CreateMessageFromTextObject(0x10D4, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"Koo, koo, koo.&I can give you #",
@@ -553,7 +553,7 @@ void CreateOtherHints() {
     /*Spanish?*/"#...^Pero solo si puedes nadar a&través de todos los #anillos# del río&en menos de #dos minutos#.",
     // /*German ?*/"#...^Aber nur, wenn du es schaffst, in&weniger als #zwei Minuten# durch&alle #Ringe# im Fluss zu schwimmen.**",
     // /*Italian?*/"#...^Ma solo se riesci a nuotare&attraverso tutti gli #anelli&#nel fiume #entro 2 minuti#.",
-  }, {QM_RED, QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false);
+  }, {QM_RED, QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
 
   CustomMessages::CreateMessageFromTextObject(0x10E0, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*NaEnglish*/"What?&He wants #",
@@ -573,28 +573,28 @@ void CreateOtherHints() {
     /*EuEnglish*/"",
     /*EuFrench */"# ?",
     /*EuSpanish*/"",
-  }, {QM_RED}, {}, {}, 0x0, false, false);
+  }, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
   CustomMessages::CreateMessageFromTextObject(0x10E1, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"Yeah...&He Wants #",
     /*French */"Ouaip...&Il veut #",
     /*Spanish?*/"Sí...&#",
     // /*German */"Ja...&#",
     // /*Italian*/"Sì...&#",
-  }+beaverBottleHint+"#.", {QM_RED}, {}, {}, 0x0, false, false);
+  }+beaverBottleHint+"#.", {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
   CustomMessages::CreateMessage(0x10E3, 0xFFFF, 0x3FFFFFFF, 0xFF0000, {
     /*English*/"Look. That's really precious to us, so just beating my little brother isn't enough.",
     /*French */"Écoute. On tient beaucoup à ça, alors une simple victoire ne suffira pas.",
     // /*Spanish*/"**SPANISH**",
     // /*German */"**GERMAN**",
     // /*Italian*/"**ITALIAN**",
-  }, {}, {}, {}, 0x0, false, false);
+  }, {}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
   CustomMessages::CreateMessage(0x10E4, 0xFFFF, 0x3FFFFFFF, 0xFF0000, {
     /*English*/"It's not enough.",
     /*French */"Ça suffit pas.",
     // /*Spanish*/"**SPANISH**",
     // /*German */"**GERMAN**",
     // /*Italian*/"**ITALIAN**",
-  }, {}, {}, {}, 0x0, false, false);
+  }, {}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
 
   CustomMessages::CreateMessageFromTextObject(0x10F5, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"This time, we only have #",
@@ -608,14 +608,14 @@ void CreateOtherHints() {
     /*Spanish?*/"#... Right, Little Brother?",
     // /*German */"#**GERMAN**",
     // /*Italian*/"#**ITALIAN**",
-  }, {QM_RED}, {}, {}, 0x0, false, false);
+  }, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
   CustomMessages::CreateMessage(0x10F6, 0xFFFF, 0x3FFFFFFF, 0xFF0000, {
     /*English*/"That's right, Big Brother...",
     /*French */"Ouaip, grand frère...",
     // /*Spanish*/"**SPANISH**",
     // /*German */"**GERMAN**",
     // /*Italian*/"**ITALIAN**",
-  }, {}, {}, {}, 0x0, false, false);
+  }, {}, {}, {}, 0x0, false, false, MESSAGE_END_NEXT);
 
   CustomMessages::CreateMessageFromTextObject(0x1240, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"You know the #beavers# above the #waterfall# are the type to have #empty bottles#, right?^Lately, they've been braggin about #",
@@ -624,7 +624,7 @@ void CreateOtherHints() {
     // /*German ?*/"You know the #beavers# above the #waterfall# are the type to have #empty bottles#, right?^Lately, they've been braggin about #",
     // /*Italian?*/"You know the #beavers# above the #waterfall# are the type to have #empty bottles#, right?^Lately, they've been braggin about #",
   }+beaverBottleHint
-  +"#.", {QM_RED, QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false);
+  +"#.", {QM_RED, QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENT);
 
   CustomMessages::CreateMessageFromTextObject(0x1242, 0xFFFF, 0x3FFFFFFF, 0xFF0000, Text{
     /*English*/"And remember what I told you about the #beavers# above the #waterfall#.^It seems like they have #",
@@ -633,7 +633,7 @@ void CreateOtherHints() {
     // /*German */"**GERMAN**#",
     // /*Italian*/"**ITALIAN**#",
   }+beaverBottleHint
-  +"#.", {QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false);
+  +"#.", {QM_RED, QM_RED, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_EVENT);
   
 
 
@@ -790,15 +790,15 @@ void CreateClockTowerDoorHints() {
       // "Porta del tetto&Ingresso vietato fino alla&#mezzanotte# della #vigilia# del&carnevale.^"
       // "**ITALIAN**",
     },
-    {QM_RED, QM_RED, QM_RED, QM_MAGENTA}, {}, {}, 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8000, ShuffleSongOfTime ? 0x8001 : 0x8002, 0x3FFFFFFF, 0x1000000, ocarinaHint, {QM_BLUE, QM_RED}, {}, {}, 0x083E, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8001, 0x8002, 0x3FFFFFFF, 0x1000000, songTimeHint, {QM_BLUE, QM_RED}, {}, {}, (clockDoorFirstHint == 0x8001) ? 0x083E : 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8002, 0x8003, 0x3FFFFFFF, 0x1FF0000, remainsPreHint, {QM_RED, QM_RED}, {}, {}, (clockDoorFirstHint == 0x8002) ? 0x083E : 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8003, 0x8004, 0x3FFFFFFF, 0x15D0000, odolwaHint, {QM_GREEN, QM_GREEN, QM_RED}, {}, {}, 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8004, 0x8005, 0x3FFFFFFF, 0x15E0000, gohtHint, {QM_MAGENTA, QM_MAGENTA, QM_RED}, {}, {}, 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8005, 0x8006, 0x3FFFFFFF, 0x15F0000, gyorgHint, {QM_CYAN, QM_CYAN, QM_RED}, {}, {}, 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8006, 0x8007, 0x3FFFFFFF, 0x1600000, twinmoldHint, {QM_YELLOW, QM_YELLOW, QM_RED}, {}, {}, 0x0, false, false);
-  CustomMessages::CreateMessageFromTextObject(0x8007, 0xFFFF, 0x3FFFFFFF, 0x0FF0000, remainsNeededHint, {QM_RED}, {}, {}, 0x0, false, false);
+    {QM_RED, QM_RED, QM_RED, QM_MAGENTA}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
+  CustomMessages::CreateMessageFromTextObject(0x8000, ShuffleSongOfTime ? 0x8001 : 0x8002, 0x3FFFFFFF, 0x000000, ocarinaHint, {QM_BLUE, QM_RED}, {}, {}, 0x083E, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8001, 0x8002, 0x3FFFFFFF, 0x000000, songTimeHint, {QM_BLUE, QM_RED}, {}, {}, (clockDoorFirstHint == 0x8001) ? 0x083E : 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8002, 0x8003, 0x3FFFFFFF, 0xFF0000, remainsPreHint, {QM_RED, QM_RED}, {}, {}, (clockDoorFirstHint == 0x8002) ? 0x083E : 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8003, 0x8004, 0x3FFFFFFF, 0x5D0000, odolwaHint, {QM_GREEN, QM_GREEN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8004, 0x8005, 0x3FFFFFFF, 0x5E0000, gohtHint, {QM_MAGENTA, QM_MAGENTA, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8005, 0x8006, 0x3FFFFFFF, 0x5F0000, gyorgHint, {QM_CYAN, QM_CYAN, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8006, 0x8007, 0x3FFFFFFF, 0x600000, twinmoldHint, {QM_YELLOW, QM_YELLOW, QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_PSEUDO);
+  CustomMessages::CreateMessageFromTextObject(0x8007, 0xFFFF, 0x3FFFFFFF, 0xFF0000, remainsNeededHint, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 }
 
 void CreateMoonChildHint() {
@@ -846,7 +846,7 @@ void CreateMoonChildHint() {
     /*Spanish*/"^**SPANISH**"
   };
 
-  CustomMessages::CreateMessageFromTextObject(0x6149, 0xFFFF, 0x3FFFFFFF, 0x0FF0020, moonChildHint, {QM_RED}, {}, {}, 0x0, false, false);
+  CustomMessages::CreateMessageFromTextObject(0x6149, 0xFFFF, 0x3FFFFFFF, 0x0FF0020, moonChildHint, {QM_RED}, {}, {}, 0x0, false, false, MESSAGE_END_NORMAL);
 }
 
 //insert the required number into the hint and set the singular/plural form

--- a/source/include/custom_messages.hpp
+++ b/source/include/custom_messages.hpp
@@ -22,11 +22,11 @@ typedef struct {
 } Language;
 void CreateMessage(u16 textId, u16 field_2, u32 field_4, u32 flags, const Language& text,
                    const std::vector<colType>& cols, const std::vector<iconType>& icons, const std::vector<u8>& delays,
-                   u16 sfx, bool instant, bool repeatSfx);
+                   u16 sfx, bool instant, bool repeatSfx, u8 messageEndType);
 
 void CreateMessageFromTextObject(u16 textId, u16 field_2, u32 field_4, u32 flags, const Text& text,
                    const std::vector<colType>& cols, const std::vector<iconType>& icons, const std::vector<u8>& delays,
-                   u16 sfx, bool instant, bool repeatSfx);
+                   u16 sfx, bool instant, bool repeatSfx, u8 messageEndType);
 
 u32 NumMessages();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -27,12 +27,12 @@ int main() {
     /*CustomMessages::CreateMessage(0x0224, 0x8000, 0x3FFFFFFF, 0xFF0000,
         "This is a test scrolling #custom message# with #multiple# #colours#, %d%e%l%a%y%s, and icons $ $ $^Let's also test filename:&#@#",
         { QM_GREEN, QM_MAGENTA, QM_CYAN, QM_RED }, { ZL_BUTTON, MAJORA_ICON, ZR_BUTTON }, { 5, 10, 15, 20, 25, 30 },
-        0x0000, false, false
+        0x0000, false, false, MESSAGE_END_NORMAL
     );
     CustomMessages::CreateMessage(0x8000, 0xFFFF, 0x3FFFFFFF, 0xFF0000,
         "This is a test instant #custom message# with #multiple# #colours#, %d%e%l%a%y%s, and icons $ $ $^Let's also test filename:&#@#",
         { QM_GREEN, QM_MAGENTA, QM_CYAN, QM_RED }, { ZL_BUTTON, MAJORA_ICON, ZR_BUTTON }, { 5, 10, 15, 20, 25, 30 },
-        0x0000, true, false
+        0x0000, true, false, MESSAGE_END_NORMAL
     );*/
 
     u64 initialHoldTime = svcGetSystemTick();


### PR DESCRIPTION
Custom Message closing characters are now set app-side, allowing better control of textbox flow, and avoiding glitches when replacing some vanilla messages
Also includes minor French hint changes