### PR TITLE
Start With Strays Fix

### DIFF
--- a/source/settings.cpp
+++ b/source/settings.cpp
@@ -774,7 +774,7 @@ namespace Settings {
     ctx.mapsAndCompasses = MapsAndCompasses.Value<u8>();
     ctx.keysanity = Keysanity.Value<u8>();
     ctx.bossKeysanity = BossKeysanity.Value<u8>();
-    //ctx.strayFairysanity = StrayFairysanity.Value<u8>();
+    ctx.strayFairysanity = StrayFairysanity.Value<u8>();
     ctx.shuffleRewards = ShuffleRewards.Value<u8>();
     //ctx.shuffleHeartContainers = (ShuffleHeartContainers) ? 1 : 0;
 

--- a/source/starting_inventory.cpp
+++ b/source/starting_inventory.cpp
@@ -54,7 +54,6 @@ void GenerateStartingInventory() {
   }
 
   if (StrayFairysanity.Value<u8>() == 1/*Start With*/) {
-    AddItemToInventory(CT_STRAY_FAIRY, 1);
     AddItemToInventory(WF_STRAY_FAIRY, 15);
     AddItemToInventory(SH_STRAY_FAIRY, 15);
     AddItemToInventory(GBT_STRAY_FAIRY, 15);


### PR DESCRIPTION
- Passes the StrayFairySanity option value to the patch side for functionality
- Removes CT Stray from being added to the starting Inventory when StrayFairySanity is set to Start With